### PR TITLE
docs: add Kiko-ryū naming exploration to README branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,22 @@ As things get real, plans may change. That’s intentional.
 
 Umbrella name: **GoblinFoxDragon**  
 Project names and branding beneath the umbrella may change over time as products take shape.
+
+### Naming exploration: 鬼狐竜 (Kiko-ryū)
+
+Possible combined Japanese rendering for the creature/archetype vibe:
+
+- **鬼 (ki)** = demon/oni spirit energy
+- **狐 (ko)** = fox
+- **竜 / 龍 (ryū)** = dragon
+
+That gives shorthand interpretations like:
+
+- **Demon Fox Dragon**
+- **Oni-Fox Dragon** (strong fantasy flavor)
+- **Fiend Fox Dragon** (darker boss tone)
+
+Why it works:
+
+- compact, mythic cadence in Japanese
+- reads like a proper named creature/class instead of a flat literal phrase


### PR DESCRIPTION
### Motivation
- Add a short branding note to capture a proposed combined Japanese name and its semantic breakdown so the repo’s naming/creature ideas are documented alongside other branding notes.

### Description
- Add a new `README.md` subsection titled "Naming exploration: 鬼狐竜 (Kiko-ryū)" that includes the kanji breakdown for `鬼` / `狐` / `竜` (or `龍`), several English gloss options, and a brief rationale for why the compound works as a mythic/boss-style name.

### Testing
- No runtime tests were required for this docs-only change, and the file content was verified using `nl -ba README.md | sed -n '95,150p'` and `rg -n "鬼狐竜|Kiko-ryū" README.md`, both of which returned the new section lines successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a69b040b48327b344c3db745656ac)