### PR TITLE
ci: include world mockup sources in Windows client build and Makefile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,13 +75,20 @@ jobs:
           set -euo pipefail
           test -f apps/lobby/src/main.c
 
-          x86_64-w64-mingw32-gcc apps/lobby/src/main.c \
+          x86_64-w64-mingw32-gcc \
+            apps/lobby/src/main.c \
+            packages/world/town_map.c \
+            packages/world/town_render.c \
+            packages/world/crisis_mock_state.c \
+            packages/world/town_debug_ui.c \
             -o GoblinFoxDragon.exe \
             -O2 -static-libgcc \
             -I./sdl2_mingw/include \
             -I. \
             -Ipackages/common \
             -Ipackages/simulation \
+            -Ipackages/world \
+            -Ipackages/ui \
             -L./sdl2_mingw/lib \
             -lmingw32 -lSDL2main -lSDL2 \
             -lopengl32 -lglu32 -lws2_32 -lwinmm -lgdi32 -lm

--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,13 @@ BIN_DIR  := bin
 
 # ---- Flags ----
 CFLAGS   := -O2 -Wall -D_REENTRANT
-INCLUDES := -Ipackages/common -Ipackages/simulation
+INCLUDES := -Ipackages/common -Ipackages/simulation -Ipackages/world -Ipackages/ui
 
 LIBS_GL  := -lSDL2 -lGL -lGLU -lm
 LIBS_M   := -lm
 
 # ---- Sources ----
-LOBBY_SRC    := apps/lobby/src/main.c
+LOBBY_SRC    := apps/lobby/src/main.c packages/world/town_map.c packages/world/town_render.c packages/world/crisis_mock_state.c packages/world/town_debug_ui.c
 SERVER_SRC   := apps/server/src/main.c
 SERVERCTL_SRC:= apps/server/serverctl.c
 
@@ -37,7 +37,7 @@ lobby: $(LOBBY_BIN)
 
 $(LOBBY_BIN): $(LOBBY_SRC) | $(BIN_DIR)
 	@echo "🔨 Building Lobby Client..."
-	$(CC) $(CFLAGS) $(INCLUDES) $< -o $@ $(LIBS_GL)
+	$(CC) $(CFLAGS) $(INCLUDES) $(LOBBY_SRC) -o $@ $(LIBS_GL)
 
 # ---- GAME SERVER ----
 server: $(SERVER_BIN)

--- a/README.md
+++ b/README.md
@@ -102,3 +102,22 @@ As things get real, plans may change. That’s intentional.
 
 Umbrella name: **GoblinFoxDragon**  
 Project names and branding beneath the umbrella may change over time as products take shape.
+
+### Naming exploration: 鬼狐竜 (Kiko-ryū)
+
+Possible combined Japanese rendering for the creature/archetype vibe:
+
+- **鬼 (ki)** = demon/oni spirit energy
+- **狐 (ko)** = fox
+- **竜 / 龍 (ryū)** = dragon
+
+That gives shorthand interpretations like:
+
+- **Demon Fox Dragon**
+- **Oni-Fox Dragon** (strong fantasy flavor)
+- **Fiend Fox Dragon** (darker boss tone)
+
+Why it works:
+
+- compact, mythic cadence in Japanese
+- reads like a proper named creature/class instead of a flat literal phrase

--- a/packages/common/physics.h
+++ b/packages/common/physics.h
@@ -94,6 +94,14 @@ static const Box map_geo_garage[] = {
 };
 
 
+static const Box map_geo_city[] = {
+    {50.0f, -2.0f, 50.0f, 140.0f, 4.0f, 140.0f},
+    {50.0f, 8.0f, -20.0f, 140.0f, 20.0f, 4.0f},
+    {50.0f, 8.0f, 120.0f, 140.0f, 20.0f, 4.0f},
+    {-20.0f, 8.0f, 50.0f, 4.0f, 20.0f, 140.0f},
+    {120.0f, 8.0f, 50.0f, 4.0f, 20.0f, 140.0f}
+};
+
 #define CITY_MAX_BOXES 2048
 static Box map_geo_voxworld[CITY_MAX_BOXES];
 static int map_geo_voxworld_count = 0;
@@ -200,6 +208,9 @@ static inline void phys_set_scene(int scene_id) {
         init_voxworld_city_geo();
         map_geo = map_geo_voxworld;
         map_count = map_geo_voxworld_count;
+    } else if (scene_id == SCENE_CITY) {
+        map_geo = map_geo_city;
+        map_count = (int)(sizeof(map_geo_city) / sizeof(Box));
     } else {
         map_geo = map_geo_stadium;
         map_count = (int)(sizeof(map_geo_stadium) / sizeof(Box));
@@ -221,6 +232,12 @@ static inline void scene_spawn_point(int scene_id, int slot, float *out_x, float
         *out_x = offsets[idx];
         *out_y = 6.0f;
         *out_z = 0.0f;
+        return;
+    }
+    if (scene_id == SCENE_CITY) {
+        *out_x = 50.0f;
+        *out_y = 5.0f;
+        *out_z = 58.0f;
         return;
     }
     if (slot % 2 == 0) {
@@ -266,6 +283,11 @@ static inline void scene_safety_check(PlayerState *p) {
         if (p->y < VOXWORLD_KILL_Y ||
             p->x < -VOXWORLD_BOUNDS_X || p->x > VOXWORLD_BOUNDS_X ||
             p->z < -VOXWORLD_BOUNDS_Z || p->z > VOXWORLD_BOUNDS_Z) {
+            scene_force_spawn(p);
+        }
+    }
+    if (p->scene_id == SCENE_CITY) {
+        if (p->y < -30.0f || p->x < -30.0f || p->x > 130.0f || p->z < -30.0f || p->z > 130.0f) {
             scene_force_spawn(p);
         }
     }
@@ -567,7 +589,7 @@ void phys_respawn(PlayerState *p, unsigned int now) {
     p->active = 1; p->state = STATE_ALIVE;
     p->health = 100; p->shield = 100; p->respawn_time = 0; p->in_vehicle = 0;
     p->use_was_down = 0;
-    if (p->scene_id != SCENE_GARAGE_OSAKA && p->scene_id != SCENE_STADIUM && p->scene_id != SCENE_VOXWORLD) {
+    if (p->scene_id != SCENE_GARAGE_OSAKA && p->scene_id != SCENE_STADIUM && p->scene_id != SCENE_VOXWORLD && p->scene_id != SCENE_CITY) {
         p->scene_id = SCENE_GARAGE_OSAKA;
     }
     scene_spawn_point(p->scene_id, p->id, &p->x, &p->y, &p->z);

--- a/packages/world/crisis_mock_state.c
+++ b/packages/world/crisis_mock_state.c
@@ -1,0 +1,52 @@
+#include "crisis_mock_state.h"
+#include <SDL2/SDL.h>
+
+void crisis_mock_state_init(CrisisMockState *s) {
+    s->phase = MOCK_PHASE_OMENS;
+    s->ley_integrity = 100.0f;
+    s->time_to_next_sec = 180;
+    s->gate_required = 3;
+    s->gate_current = 0;
+    s->gate_anchor_met = 0;
+    s->gate_ritual_met = 0;
+    s->gate_intercept_met = 0;
+    s->overlay_on = 1;
+    s->labels_on = 1;
+    s->pressure_idx = 0;
+    s->topdown_on = 0;
+    s->noclip_on = 0;
+}
+
+const char *crisis_mock_phase_name(MockPhase p) {
+    static const char *names[] = {"OMENS", "BURROW", "EMERGENCE", "SPLIT WAR", "FINAL WINDOW", "RESOLUTION"};
+    return names[(int)p < 0 || (int)p > 5 ? 0 : (int)p];
+}
+
+const char *crisis_mock_phase_prompt(MockPhase p) {
+    switch (p) {
+        case MOCK_PHASE_OMENS: return "Scout reports and prep town routes.";
+        case MOCK_PHASE_BURROW: return "Harden anchor lines and stage intercept teams.";
+        case MOCK_PHASE_EMERGENCE: return "Contest ritual points and hold central spine.";
+        case MOCK_PHASE_SPLIT_WAR: return "Split force to docks/mines heads now.";
+        case MOCK_PHASE_FINAL_WINDOW: return "Seal final gate. Burn priority targets.";
+        default: return "Crisis stabilized. Reset and review routes.";
+    }
+}
+
+static float clampf(float v, float lo, float hi) { return v < lo ? lo : (v > hi ? hi : v); }
+
+void crisis_mock_state_handle_key(CrisisMockState *s, int key) {
+    if (key >= SDLK_1 && key <= SDLK_6) s->phase = (MockPhase)(key - SDLK_1);
+    else if (key == SDLK_LEFTBRACKET) s->ley_integrity = clampf(s->ley_integrity - 5.0f, 0.0f, 100.0f);
+    else if (key == SDLK_RIGHTBRACKET) s->ley_integrity = clampf(s->ley_integrity + 5.0f, 0.0f, 100.0f);
+    else if (key == SDLK_MINUS) s->gate_current = s->gate_current > 0 ? s->gate_current - 1 : 0;
+    else if (key == SDLK_EQUALS) s->gate_current = s->gate_current < 9 ? s->gate_current + 1 : 9;
+    else if (key == SDLK_F1) s->overlay_on = !s->overlay_on;
+    else if (key == SDLK_F2) s->labels_on = !s->labels_on;
+    else if (key == SDLK_F3) s->pressure_idx = (s->pressure_idx + 1) % 3;
+    else if (key == SDLK_z) s->gate_anchor_met = !s->gate_anchor_met;
+    else if (key == SDLK_x) s->gate_ritual_met = !s->gate_ritual_met;
+    else if (key == SDLK_c) s->gate_intercept_met = !s->gate_intercept_met;
+    else if (key == SDLK_m) s->topdown_on = !s->topdown_on;
+    else if (key == SDLK_n) s->noclip_on = !s->noclip_on;
+}

--- a/packages/world/crisis_mock_state.h
+++ b/packages/world/crisis_mock_state.h
@@ -1,0 +1,26 @@
+#ifndef CRISIS_MOCK_STATE_H
+#define CRISIS_MOCK_STATE_H
+
+typedef enum { MOCK_PHASE_OMENS = 0, MOCK_PHASE_BURROW, MOCK_PHASE_EMERGENCE, MOCK_PHASE_SPLIT_WAR, MOCK_PHASE_FINAL_WINDOW, MOCK_PHASE_RESOLUTION } MockPhase;
+typedef struct {
+    MockPhase phase;
+    float ley_integrity;
+    int time_to_next_sec;
+    int gate_required;
+    int gate_current;
+    int gate_anchor_met;
+    int gate_ritual_met;
+    int gate_intercept_met;
+    int overlay_on;
+    int labels_on;
+    int pressure_idx;
+    int topdown_on;
+    int noclip_on;
+} CrisisMockState;
+
+void crisis_mock_state_init(CrisisMockState *state);
+void crisis_mock_state_handle_key(CrisisMockState *state, int keycode);
+const char *crisis_mock_phase_name(MockPhase phase);
+const char *crisis_mock_phase_prompt(MockPhase phase);
+
+#endif

--- a/packages/world/town_debug_ui.c
+++ b/packages/world/town_debug_ui.c
@@ -1,0 +1,34 @@
+#include "town_debug_ui.h"
+#include <stdio.h>
+#include <string.h>
+#include <SDL2/SDL_opengl.h>
+#include "../ui/turtle_text.h"
+#include "crisis_mock_state.h"
+
+static void draw_string2(const char *str, float x, float y, float size) {
+    TurtlePen pen;
+    turtle_pen_begin(&pen, x, y, size);
+    turtle_draw_text(&pen, str);
+}
+
+void town_debug_ui_draw(const CrisisMockState *s, const char *routes_line) {
+    if (!s || !s->overlay_on) return;
+    char line[256];
+    glColor3f(1.0f, 0.5f, 0.2f);
+    draw_string2("WORLD CRISIS: THE SUNDERWORM", 30, 690, 7);
+    glColor3f(0.8f, 0.9f, 1.0f);
+    snprintf(line, sizeof(line), "Phase: %s", crisis_mock_phase_name(s->phase));
+    draw_string2(line, 30, 665, 5);
+    snprintf(line, sizeof(line), "Ley Integrity: %.0f%%", s->ley_integrity);
+    draw_string2(line, 30, 645, 5);
+    snprintf(line, sizeof(line), "Escalation ETA: %ds", s->time_to_next_sec);
+    draw_string2(line, 30, 625, 5);
+    snprintf(line, sizeof(line), "Gate: %d/%d   A:%s R:%s I:%s", s->gate_current, s->gate_required,
+             s->gate_anchor_met ? "Y" : "N", s->gate_ritual_met ? "Y" : "N", s->gate_intercept_met ? "Y" : "N");
+    draw_string2(line, 30, 605, 5);
+    draw_string2(crisis_mock_phase_prompt(s->phase), 30, 585, 4);
+    if (routes_line && routes_line[0]) {
+        glColor3f(0.9f, 0.8f, 0.2f);
+        draw_string2(routes_line, 30, 560, 4);
+    }
+}

--- a/packages/world/town_debug_ui.h
+++ b/packages/world/town_debug_ui.h
@@ -1,0 +1,5 @@
+#ifndef TOWN_DEBUG_UI_H
+#define TOWN_DEBUG_UI_H
+#include "crisis_mock_state.h"
+void town_debug_ui_draw(const CrisisMockState *state, const char *routes_line);
+#endif

--- a/packages/world/town_map.c
+++ b/packages/world/town_map.c
@@ -1,0 +1,43 @@
+#include "town_map.h"
+
+static const TownBuilding g_buildings[] = {
+    {BLD_AUCTION_HOUSE, "Auction House", 50, 52, 34, 8, 8, 0},
+    {BLD_TOWN_HALL, "Town Hall", 66, 61, 10, 8, 10, 0},
+    {BLD_GUILD_HOUSE, "Guild House", 36, 58, 10, 8, 8, 0},
+    {BLD_GOLD_GUILD, "Gold Guild", 28, 56, 10, 8, 8, 0},
+    {BLD_POST_OFFICE, "Post Office", 22, 44, 12, 8, 7, 0},
+    {BLD_BLACKSMITH, "Blacksmith", 28, 68, 8, 8, 8, 0},
+    {BLD_WEAPONS_GUILD, "Weapons Guild", 33, 82, 14, 10, 8, 0},
+    {BLD_POTIONS, "Potions", 58, 66, 8, 8, 7, 0},
+    {BLD_ALCHEMY_SHOP, "Alchemy Shop", 72, 66, 10, 8, 7, 0},
+    {BLD_SHADY_DEALER, "Shady Dealer", 82, 60, 10, 8, 8, 0},
+    {BLD_FISH_SHOP, "Fish Shop", 52, 86, 10, 8, 7, 0},
+    {BLD_ARMOR_SHOP, "Armor Shop", 72, 74, 10, 8, 8, 0},
+    {BLD_MINECO_OPS, "Mineco Ops", 45, 26, 12, 8, 8, 0},
+    {BLD_MINING_SUPPLIES, "Mining Supplies", 60, 26, 12, 8, 8, 0},
+    {BLD_ARCHERY_GUILD, "Archery Guild", 84, 40, 12, 10, 8, 0},
+    {BLD_POLICE, "Police", 66, 34, 8, 6, 7, 0},
+    {BLD_GLOVE_SHOP, "Glove Shop", 80, 22, 8, 8, 7, 0},
+};
+
+static const CrisisSocket g_sockets[] = {
+    {SOCK_ANCHOR_AUCTION, "Anchor: Auction", 52, 58, 3.5f, SOCK_ROLE_BUILDER, 1},
+    {SOCK_RITUAL_TOWN_HALL, "Ritual: Town Hall", 66, 61, 3.5f, SOCK_ROLE_RITUALIST, 1},
+    {SOCK_INTERCEPT_DOCK_ROUTE, "Intercept: Docks", 84, 86, 4.0f, SOCK_ROLE_STRIKE | SOCK_ROLE_SCOUT, 1},
+    {SOCK_INTERCEPT_MINES_ROUTE, "Intercept: Mines", 88, 20, 4.0f, SOCK_ROLE_STRIKE | SOCK_ROLE_SCOUT, 1},
+    {SOCK_HEAD_A_DOCKS, "Head A: Docks Edge", 90, 82, 4.5f, SOCK_ROLE_STRIKE, 0},
+    {SOCK_HEAD_B_MINES, "Head B: Mines Edge", 92, 18, 4.5f, SOCK_ROLE_STRIKE, 0},
+    {SOCK_SECRET_GATE_PRESSURE, "Secret Gate Pressure", 12, 20, 3.0f, SOCK_ROLE_SCOUT, 1}
+};
+
+static const TownRoutePoint g_routes[] = {
+    {"Auction", 50, 52},
+    {"Docks", 90, 86},
+    {"Mines", 90, 20},
+    {"Secret Gate", 12, 20},
+    {"Town Hall", 66, 61}
+};
+
+const TownBuilding *town_map_buildings(size_t *count) { if (count) *count = sizeof(g_buildings) / sizeof(g_buildings[0]); return g_buildings; }
+const CrisisSocket *town_map_sockets(size_t *count) { if (count) *count = sizeof(g_sockets) / sizeof(g_sockets[0]); return g_sockets; }
+const TownRoutePoint *town_map_route_points(size_t *count) { if (count) *count = sizeof(g_routes) / sizeof(g_routes[0]); return g_routes; }

--- a/packages/world/town_map.h
+++ b/packages/world/town_map.h
@@ -1,0 +1,13 @@
+#ifndef TOWN_MAP_H
+#define TOWN_MAP_H
+#include <stddef.h>
+typedef enum { BLD_AUCTION_HOUSE = 0, BLD_TOWN_HALL, BLD_GUILD_HOUSE, BLD_GOLD_GUILD, BLD_POST_OFFICE, BLD_BLACKSMITH, BLD_WEAPONS_GUILD, BLD_POTIONS, BLD_ALCHEMY_SHOP, BLD_SHADY_DEALER, BLD_FISH_SHOP, BLD_ARMOR_SHOP, BLD_MINECO_OPS, BLD_MINING_SUPPLIES, BLD_ARCHERY_GUILD, BLD_POLICE, BLD_GLOVE_SHOP, BLD_MISC_COUNT } TownBuildingId;
+typedef struct { TownBuildingId id; const char *label; float x, z; float w, d; float h; unsigned int tags; } TownBuilding;
+typedef enum { SOCK_ANCHOR_AUCTION = 0, SOCK_RITUAL_TOWN_HALL, SOCK_INTERCEPT_DOCK_ROUTE, SOCK_INTERCEPT_MINES_ROUTE, SOCK_HEAD_A_DOCKS, SOCK_HEAD_B_MINES, SOCK_SECRET_GATE_PRESSURE, SOCK_COUNT } CrisisSocketId;
+typedef enum { SOCK_ROLE_STRIKE = 1 << 0, SOCK_ROLE_BUILDER = 1 << 1, SOCK_ROLE_RITUALIST = 1 << 2, SOCK_ROLE_SCOUT = 1 << 3 } SocketRoleFlags;
+typedef struct { CrisisSocketId id; const char *label; float x, z; float radius; unsigned int role_flags; int counts_for_final_gate; } CrisisSocket;
+typedef struct { const char *label; float x, z; } TownRoutePoint;
+const TownBuilding *town_map_buildings(size_t *count);
+const CrisisSocket *town_map_sockets(size_t *count);
+const TownRoutePoint *town_map_route_points(size_t *count);
+#endif

--- a/packages/world/town_render.c
+++ b/packages/world/town_render.c
@@ -1,0 +1,72 @@
+#include "town_render.h"
+#include "town_map.h"
+#include <SDL2/SDL_opengl.h>
+#include <math.h>
+#include <stdio.h>
+
+static void draw_box(float x, float y, float z, float w, float h, float d, float r, float g, float b) {
+    glPushMatrix();
+    glTranslatef(x, y, z);
+    glScalef(w, h, d);
+    glColor3f(r, g, b);
+    glBegin(GL_QUADS);
+    glVertex3f(-0.5f,-0.5f,0.5f); glVertex3f(0.5f,-0.5f,0.5f); glVertex3f(0.5f,0.5f,0.5f); glVertex3f(-0.5f,0.5f,0.5f);
+    glVertex3f(-0.5f,-0.5f,-0.5f); glVertex3f(-0.5f,0.5f,-0.5f); glVertex3f(0.5f,0.5f,-0.5f); glVertex3f(0.5f,-0.5f,-0.5f);
+    glVertex3f(-0.5f,-0.5f,-0.5f); glVertex3f(-0.5f,-0.5f,0.5f); glVertex3f(-0.5f,0.5f,0.5f); glVertex3f(-0.5f,0.5f,-0.5f);
+    glVertex3f(0.5f,-0.5f,-0.5f); glVertex3f(0.5f,0.5f,-0.5f); glVertex3f(0.5f,0.5f,0.5f); glVertex3f(0.5f,-0.5f,0.5f);
+    glVertex3f(-0.5f,0.5f,0.5f); glVertex3f(0.5f,0.5f,0.5f); glVertex3f(0.5f,0.5f,-0.5f); glVertex3f(-0.5f,0.5f,-0.5f);
+    glVertex3f(-0.5f,-0.5f,0.5f); glVertex3f(-0.5f,-0.5f,-0.5f); glVertex3f(0.5f,-0.5f,-0.5f); glVertex3f(0.5f,-0.5f,0.5f);
+    glEnd();
+    glPopMatrix();
+}
+
+static void draw_ring(float x, float z, float y, float radius, float r, float g, float b) {
+    glColor3f(r, g, b);
+    glBegin(GL_LINE_LOOP);
+    for (int i = 0; i < 32; i++) {
+        float a = ((float)i / 32.0f) * 6.2831853f;
+        glVertex3f(x + cosf(a) * radius, y, z + sinf(a) * radius);
+    }
+    glEnd();
+}
+
+void town_render_world(const CrisisMockState *state) {
+    draw_box(50.0f, -1.5f, 50.0f, 120.0f, 3.0f, 120.0f, 0.04f, 0.04f, 0.05f);
+    draw_box(50.0f, 2.0f, 50.0f, 100.0f, 4.0f, 2.0f, 0.12f, 0.12f, 0.14f);
+    draw_box(50.0f, 2.0f, 50.0f, 2.0f, 4.0f, 100.0f, 0.12f, 0.12f, 0.14f);
+    draw_box(50.0f, 2.0f, 100.0f, 100.0f, 4.0f, 2.0f, 0.20f, 0.20f, 0.22f);
+    draw_box(50.0f, 2.0f, 0.0f, 100.0f, 4.0f, 2.0f, 0.20f, 0.20f, 0.22f);
+
+    size_t bcount = 0;
+    const TownBuilding *b = town_map_buildings(&bcount);
+    for (size_t i = 0; i < bcount; i++) {
+        float base = (b[i].id == BLD_AUCTION_HOUSE) ? 0.09f : 0.06f;
+        draw_box(b[i].x, b[i].h * 0.5f, b[i].z, b[i].w, b[i].h, b[i].d, base, base, base + 0.02f);
+    }
+
+    size_t scount = 0;
+    const CrisisSocket *s = town_map_sockets(&scount);
+    for (size_t i = 0; i < scount; i++) {
+        float r = 1.0f, g = 0.4f, bcol = 0.1f;
+        if (s[i].id == SOCK_ANCHOR_AUCTION) { r = 0.1f; g = 1.0f; bcol = 1.0f; }
+        else if (s[i].id == SOCK_RITUAL_TOWN_HALL) { r = 0.7f; g = 0.2f; bcol = 1.0f; }
+        else if (s[i].id == SOCK_HEAD_A_DOCKS || s[i].id == SOCK_HEAD_B_MINES) { r = 1.0f; g = 0.1f; bcol = 0.1f; }
+        draw_box(s[i].x, 4.0f, s[i].z, 1.2f, 8.0f, 1.2f, r, g, bcol);
+        draw_ring(s[i].x, s[i].z, 0.2f, s[i].radius, r, g, bcol);
+        if (state && state->pressure_idx > 0 && (int)(i % 3) == (state->pressure_idx - 1)) {
+            draw_ring(s[i].x, s[i].z, 0.4f, s[i].radius + 1.3f, 1.0f, 1.0f, 1.0f);
+        }
+    }
+}
+
+void town_render_route_distances(float px, float pz, char *out, int out_sz) {
+    size_t n = 0;
+    const TownRoutePoint *pts = town_map_route_points(&n);
+    int used = snprintf(out, out_sz, "Routes:");
+    for (size_t i = 0; i < n && used < out_sz; i++) {
+        float dx = pts[i].x - px;
+        float dz = pts[i].z - pz;
+        float d = sqrtf(dx * dx + dz * dz);
+        used += snprintf(out + used, out_sz - used, " %s %.1fm", pts[i].label, d);
+    }
+}

--- a/packages/world/town_render.h
+++ b/packages/world/town_render.h
@@ -1,0 +1,6 @@
+#ifndef TOWN_RENDER_H
+#define TOWN_RENDER_H
+#include "crisis_mock_state.h"
+void town_render_world(const CrisisMockState *state);
+void town_render_route_distances(float px, float pz, char *out, int out_sz);
+#endif


### PR DESCRIPTION
### Motivation
- The Windows CI build and local Makefile were linking `apps/lobby/src/main.c` alone, causing undefined references to functions implemented in the newly added world mockup modules (e.g. `town_render_world`, `crisis_mock_state_init`).
- Ensure the new world package compiles and links both in CI cross-compile and local builds so the lobby can call the mockup APIs without linker errors.

### Description
- Updated the Windows client compile step in `.github/workflows/build.yml` to pass `packages/world/town_map.c`, `packages/world/town_render.c`, `packages/world/crisis_mock_state.c`, and `packages/world/town_debug_ui.c` to the `x86_64-w64-mingw32-gcc` command and added `-Ipackages/world` and `-Ipackages/ui` include paths.
- Updated `Makefile` to add `-Ipackages/world -Ipackages/ui` to `INCLUDES`, expanded `LOBBY_SRC` to include the world source files, and changed the lobby link invocation to compile `$(LOBBY_SRC)` instead of only `$<` so the world modules are built into the lobby binary.

### Testing
- Verified the workflow changes are present with `rg -n` checking for `x86_64-w64-mingw32-gcc` and the added `packages/world` entries, which returned the updated lines (success).
- Inspected the modified workflow block with `nl -ba .github/workflows/build.yml | sed -n '72,98p'` to confirm the added source files and include flags are in place (success).
- Committed the fix locally; full cross-compile CI run was not re-executed in this environment, so the change was not validated by a complete Windows build here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a69b040b48327b344c3db745656ac)