### PR TITLE
Wire New Hanclington scene through lobby UI and routing

### DIFF
--- a/packages/common/protocol.h
+++ b/packages/common/protocol.h
@@ -10,6 +10,17 @@
 #define SCENE_STADIUM 1
 #define SCENE_VOXWORLD 2
 #define SCENE_CITY 3
+#define SCENE_NEW_HANCLINGTON SCENE_CITY
+
+static inline const char *scene_id_name(int scene_id) {
+    switch (scene_id) {
+        case SCENE_GARAGE_OSAKA: return "SCENE_GARAGE_OSAKA";
+        case SCENE_STADIUM: return "SCENE_STADIUM";
+        case SCENE_VOXWORLD: return "SCENE_VOXWORLD";
+        case SCENE_CITY: return "SCENE_NEW_HANCLINGTON";
+        default: return "SCENE_UNKNOWN";
+    }
+}
 
 #define PACKET_CONNECT 0
 #define PACKET_USERCMD 1

--- a/packages/simulation/local_game.h
+++ b/packages/simulation/local_game.h
@@ -4,6 +4,7 @@
 #include "../common/protocol.h"
 #include "../common/physics.h"
 #include "../common/shared_movement.h"
+#include <stdio.h>
 #include <string.h>
 
 ServerState local_state;
@@ -48,6 +49,7 @@ PlayerState* get_best_bot() {
 }
 
 static inline void scene_load(int scene_id) {
+    printf("[SCENE] load resolved=%s (%d)\n", scene_id_name(scene_id), scene_id);
     local_state.scene_id = scene_id;
     phys_set_scene(scene_id);
     for (int i = 0; i < MAX_CLIENTS; i++) {


### PR DESCRIPTION
### Motivation
- Make the new town mockup reachable from the existing lobby UI and ensure the scene selection actually routes to the town implementation instead of showing the default Shankpit content. 
- Provide minimal debug hooks and logging to verify scene resolution at startup and on runtime scene switches.

### Description
- Added `SCENE_NEW_HANCLINGTON` alias and a `scene_id_name` helper in `packages/common/protocol.h` so the town scene resolves cleanly in logs and mappings. 
- Instrumented `scene_load` in `packages/simulation/local_game.h` with a log line to show resolved scene names at runtime. 
- Implemented a lobby scene resolver and accepted aliases (`NEW_HANCLINGTON_MOCKUP`, `NEW_HANCLINGTON`, `SCENE_CITY`) in `apps/lobby/src/main.c` and replaced the brittle string-to-scene logic with `lobby_resolve_scene_id`. 
- Added a compact scene selection UI group (Garage, Stadium, New Hanclington) with matching button style, hit-testing, and click wiring so local launches use the selected scene; clicks call `lobby_apply_scene_id` which routes to `scene_load`. 
- Added a compile-time debug boot flag `DEBUG_BOOT_NEW_HANCLINGTON` and an `F9` keybind to jump to the town scene for fast testing, plus startup logs to surface the initial scene resolution. 

### Testing
- Searched the tree for town assets and scene symbols with `rg` and confirmed town sources and render functions exist (`town_map.c`, `town_render.c`, `town_render_world`) and they are included in the lobby build list. 
- Ran `make lobby` to validate integration and the compile failed in this environment due to missing SDL2 development headers (`SDL2/SDL.h: No such file or directory`), so full runtime verification could not be executed here. 
- Verified source edits and added logging/statements by inspecting `apps/lobby/src/main.c`, `packages/common/protocol.h`, and `packages/simulation/local_game.h`; the new logs will print scene routing at startup and on `scene_load` when built and run in an environment with SDL2 available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a78677f508327a9cb4d840afd5e8a)