### PR TITLE
Add configurable leading for multiline turtle text

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -418,7 +418,9 @@ static void client_apply_spawn_transition_sync(PlayerState *p, const NetPlayer *
 
 void draw_string(const char* str, float x, float y, float size) {
     TurtlePen pen = turtle_pen_create(x, y, size);
-    turtle_draw_text(&pen, str);
+    TurtleTextLayout layout = turtle_text_layout_default();
+    layout.line_gap = 0.75f;
+    turtle_draw_text_ex(&pen, str, &layout);
 }
 
 static int project_world_to_screen(float wx, float wy, float wz,

--- a/packages/world/town_debug_ui.c
+++ b/packages/world/town_debug_ui.c
@@ -6,7 +6,9 @@
 
 static void draw_string2(const char *str, float x, float y, float size) {
     TurtlePen pen = turtle_pen_create(x, y, size);
-    turtle_draw_text(&pen, str);
+    TurtleTextLayout layout = turtle_text_layout_default();
+    layout.line_gap = 0.75f;
+    turtle_draw_text_ex(&pen, str, &layout);
 }
 
 void town_debug_ui_draw(const CrisisMockState *s, const char *routes_line) {


### PR DESCRIPTION
### Motivation
- Multiline debug/world text lines were rendering too close together and needed a small vertical gap (leading) to improve readability while preserving the existing typography.
- The change must be package-level so all callers benefit, must not change glyph shapes, horizontal advances, or letter spacing, and should be opt-in with sensible defaults.

### Description
- Introduced `TurtleTextLayout` with a `line_gap` field and `turtle_text_layout_default()` in `packages/ui/turtle_text.h` to represent configurable inter-line spacing (default `0.0f`).
- Added `turtle_draw_text_ex(TurtlePen *pen, const char *text, const TurtleTextLayout *layout)` which processes `\n` centrally and advances the pen Y by `line_height + leading` while preserving horizontal advance (`pen->x += cell * 6.0f`).
- Kept `turtle_draw_text(...)` as a backward-compatible wrapper that calls the `_ex` path with the default layout, and added `turtle_measure_text_ex` / `turtle_measure_text` which include leading in multi-line height calculations (leading applies between lines only).
- Applied a conservative default `line_gap = 0.75f` in the world/debug wrappers at `apps/lobby/src/main.c` and `packages/world/town_debug_ui.c` so large stacked metadata/title text becomes more readable without changing single-line rendering.

### Testing
- Attempted to build the lobby target with `make lobby` to validate compilation and linkage, but the build could not complete in this environment due to missing SDL2 headers (`SDL2/SDL.h`, `SDL2/SDL_opengl.h`), so compile-time verification was not possible here.
- All changes were committed and package-level APIs remain backward-compatible; runtime verification should be performed in an environment with SDL2 dev headers installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a942185e0832791c9a139153ec90d)