### PR TITLE
Add Warehouse scene with lobby selection and collision-safe geometry

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -583,6 +583,7 @@ static const LobbySceneOption LOBBY_SCENE_OPTIONS[] = {
     {"Garage", "GARAGE_OSAKA", SCENE_GARAGE_OSAKA},
     {"Stadium", "STADIUM", SCENE_STADIUM},
     {"New Hanclington", "NEW_HANCLINGTON_MOCKUP", SCENE_NEW_HANCLINGTON},
+    {"Warehouse", "WAREHOUSE", SCENE_WAREHOUSE},
     {"Mines", "MINES", SCENE_MINES}
 };
 
@@ -664,6 +665,8 @@ static int lobby_resolve_scene_id(const char *scene_id) {
     if (strcmp(scene_id, "NEW_HANCLINGTON_MOCKUP") == 0) return SCENE_NEW_HANCLINGTON;
     if (strcmp(scene_id, "NEW_HANCLINGTON") == 0) return SCENE_NEW_HANCLINGTON;
     if (strcmp(scene_id, "SCENE_CITY") == 0) return SCENE_NEW_HANCLINGTON;
+    if (strcmp(scene_id, "WAREHOUSE") == 0) return SCENE_WAREHOUSE;
+    if (strcmp(scene_id, "SCENE_WAREHOUSE") == 0) return SCENE_WAREHOUSE;
     if (strcmp(scene_id, "MINES") == 0) return SCENE_MINES;
     if (strcmp(scene_id, "SCENE_MINES") == 0) return SCENE_MINES;
     return -1;
@@ -1067,6 +1070,17 @@ void draw_map() {
         if(nr > 0.8f) nr = 1.0f;
         if(ng > 0.8f) ng = 1.0f;
         if(nb > 0.8f) nb = 1.0f;
+
+        if (local_state.scene_id == SCENE_WAREHOUSE) {
+            nr = 0.18f + 0.10f * sinf(b.x * 0.010f);
+            ng = 0.40f + 0.18f * sinf((b.x + b.z) * 0.008f + 1.4f);
+            nb = 0.46f + 0.18f * sinf(b.z * 0.010f + 2.5f);
+            if (b.z > 70.0f && b.h > 40.0f && b.d < 8.5f) {
+                nr = 0.26f;
+                ng = 0.65f;
+                nb = 0.52f;
+            }
+        }
 
         glPushMatrix(); 
         glTranslatef(b.x, b.y, b.z); 
@@ -1723,6 +1737,8 @@ void draw_scene(PlayerState *render_p) {
         town_debug_ui_draw(&crisis_mock_state, route_line);
     } else if (render_p->scene_id == SCENE_MINES) {
         mines_draw_route_labels_2d(render_p);
+    } else if (render_p->scene_id == SCENE_WAREHOUSE) {
+        draw_string("WAREHOUSE FLOOR / LOADING YARD", 42.0f, 92.0f, 4);
     }
     draw_travel_overlay();
 }

--- a/packages/common/physics.h
+++ b/packages/common/physics.h
@@ -149,6 +149,63 @@ static const Box map_geo_mines[] = {
     {104.0f, 2.0f, 146.0f, 4.5f, 4.0f, 4.5f},
     {-2.0f, 2.0f, 168.0f, 4.5f, 4.0f, 4.5f}
 };
+
+static const Box map_geo_warehouse[] = {
+    // Base floor: interior + loading yard apron
+    {0.0f, -2.0f, 20.0f, 360.0f, 4.0f, 420.0f},
+    {0.0f, -6.0f, 20.0f, 372.0f, 2.0f, 432.0f},
+
+    // Interior hall shell
+    {0.0f, 35.0f, -92.0f, 340.0f, 70.0f, 8.0f},
+    {-170.0f, 35.0f, -10.0f, 8.0f, 70.0f, 188.0f},
+    {170.0f, 35.0f, -10.0f, 8.0f, 70.0f, 188.0f},
+    {0.0f, 66.0f, -10.0f, 340.0f, 4.0f, 188.0f},
+
+    // Loading-door wall: segmented so bays remain open
+    {-138.0f, 32.0f, 84.0f, 64.0f, 64.0f, 6.0f},
+    {-46.0f, 32.0f, 84.0f, 64.0f, 64.0f, 6.0f},
+    {46.0f, 32.0f, 84.0f, 64.0f, 64.0f, 6.0f},
+    {138.0f, 32.0f, 84.0f, 64.0f, 64.0f, 6.0f},
+    {-172.0f, 32.0f, 84.0f, 4.0f, 64.0f, 6.0f},
+    {172.0f, 32.0f, 84.0f, 4.0f, 64.0f, 6.0f},
+
+    // Yard perimeter and far wall
+    {0.0f, 18.0f, 224.0f, 360.0f, 36.0f, 8.0f},
+    {-172.0f, 18.0f, 172.0f, 8.0f, 36.0f, 104.0f},
+    {172.0f, 18.0f, 172.0f, 8.0f, 36.0f, 104.0f},
+
+    // Support columns
+    {-120.0f, 18.0f, -52.0f, 10.0f, 36.0f, 10.0f},
+    {-60.0f, 18.0f, -52.0f, 10.0f, 36.0f, 10.0f},
+    {0.0f, 18.0f, -52.0f, 10.0f, 36.0f, 10.0f},
+    {60.0f, 18.0f, -52.0f, 10.0f, 36.0f, 10.0f},
+    {120.0f, 18.0f, -52.0f, 10.0f, 36.0f, 10.0f},
+    {-120.0f, 18.0f, 0.0f, 10.0f, 36.0f, 10.0f},
+    {-60.0f, 18.0f, 0.0f, 10.0f, 36.0f, 10.0f},
+    {0.0f, 18.0f, 0.0f, 10.0f, 36.0f, 10.0f},
+    {60.0f, 18.0f, 0.0f, 10.0f, 36.0f, 10.0f},
+    {120.0f, 18.0f, 0.0f, 10.0f, 36.0f, 10.0f},
+    {-120.0f, 18.0f, 52.0f, 10.0f, 36.0f, 10.0f},
+    {-60.0f, 18.0f, 52.0f, 10.0f, 36.0f, 10.0f},
+    {0.0f, 18.0f, 52.0f, 10.0f, 36.0f, 10.0f},
+    {60.0f, 18.0f, 52.0f, 10.0f, 36.0f, 10.0f},
+    {120.0f, 18.0f, 52.0f, 10.0f, 36.0f, 10.0f},
+
+    // Overhead beam/light strips
+    {-85.0f, 58.0f, -10.0f, 4.0f, 4.0f, 164.0f},
+    {0.0f, 58.0f, -10.0f, 4.0f, 4.0f, 164.0f},
+    {85.0f, 58.0f, -10.0f, 4.0f, 4.0f, 164.0f},
+
+    // Cover props / crates / low barriers
+    {-108.0f, 3.0f, 118.0f, 34.0f, 6.0f, 18.0f},
+    {106.0f, 3.0f, 136.0f, 28.0f, 6.0f, 18.0f},
+    {0.0f, 4.0f, 162.0f, 42.0f, 8.0f, 16.0f},
+    {-38.0f, 4.5f, -24.0f, 22.0f, 9.0f, 18.0f},
+    {36.0f, 4.5f, 24.0f, 22.0f, 9.0f, 18.0f},
+
+    // Back-wall catwalk illusion ledge
+    {0.0f, 24.0f, -82.0f, 144.0f, 2.0f, 12.0f}
+};
 #define CITY_MAX_BOXES 2048
 static Box map_geo_voxworld[CITY_MAX_BOXES];
 static int map_geo_voxworld_count = 0;
@@ -171,6 +228,9 @@ static int map_count = 0;
 #define MINES_KILL_Y -80.0f
 #define MINES_BOUNDS_X 180.0f
 #define MINES_BOUNDS_Z 220.0f
+#define WAREHOUSE_KILL_Y -70.0f
+#define WAREHOUSE_BOUNDS_X 184.0f
+#define WAREHOUSE_BOUNDS_Z 236.0f
 #define VOXWORLD_SEED 1337
 
 #define GARAGE_PORTAL_X 0.0f
@@ -264,6 +324,9 @@ static inline void phys_set_scene(int scene_id) {
     } else if (scene_id == SCENE_MINES) {
         map_geo = map_geo_mines;
         map_count = (int)(sizeof(map_geo_mines) / sizeof(Box));
+    } else if (scene_id == SCENE_WAREHOUSE) {
+        map_geo = map_geo_warehouse;
+        map_count = (int)(sizeof(map_geo_warehouse) / sizeof(Box));
     } else {
         map_geo = map_geo_stadium;
         map_count = (int)(sizeof(map_geo_stadium) / sizeof(Box));
@@ -297,6 +360,14 @@ static inline void scene_spawn_point(int scene_id, int slot, float *out_x, float
         *out_x = -4.0f + ((float)(slot % 5) * 2.0f);
         *out_y = 0.0f;
         *out_z = -92.0f;
+        return;
+    }
+    if (scene_id == SCENE_WAREHOUSE) {
+        float offsets[] = {-16.0f, -8.0f, 0.0f, 8.0f, 16.0f};
+        int idx = slot % 5;
+        *out_x = offsets[idx];
+        *out_y = 0.0f;
+        *out_z = -62.0f;
         return;
     }
     if (slot % 2 == 0) {
@@ -355,6 +426,14 @@ static inline void scene_safety_check(PlayerState *p) {
         if (p->y < MINES_KILL_Y ||
             p->x < -MINES_BOUNDS_X || p->x > MINES_BOUNDS_X ||
             p->z < -MINES_BOUNDS_Z || p->z > MINES_BOUNDS_Z) {
+            scene_force_spawn(p);
+        }
+        return;
+    }
+    if (p->scene_id == SCENE_WAREHOUSE) {
+        if (p->y < WAREHOUSE_KILL_Y ||
+            p->x < -WAREHOUSE_BOUNDS_X || p->x > WAREHOUSE_BOUNDS_X ||
+            p->z < -WAREHOUSE_BOUNDS_Z || p->z > WAREHOUSE_BOUNDS_Z) {
             scene_force_spawn(p);
         }
     }
@@ -656,7 +735,7 @@ void phys_respawn(PlayerState *p, unsigned int now) {
     p->active = 1; p->state = STATE_ALIVE;
     p->health = 100; p->shield = 100; p->respawn_time = 0; p->in_vehicle = 0;
     p->use_was_down = 0;
-    if (p->scene_id != SCENE_GARAGE_OSAKA && p->scene_id != SCENE_STADIUM && p->scene_id != SCENE_VOXWORLD && p->scene_id != SCENE_CITY && p->scene_id != SCENE_MINES) {
+    if (p->scene_id != SCENE_GARAGE_OSAKA && p->scene_id != SCENE_STADIUM && p->scene_id != SCENE_VOXWORLD && p->scene_id != SCENE_CITY && p->scene_id != SCENE_MINES && p->scene_id != SCENE_WAREHOUSE) {
         p->scene_id = SCENE_GARAGE_OSAKA;
     }
     scene_spawn_point(p->scene_id, p->id, &p->x, &p->y, &p->z);

--- a/packages/common/protocol.h
+++ b/packages/common/protocol.h
@@ -11,6 +11,7 @@
 #define SCENE_VOXWORLD 2
 #define SCENE_CITY 3
 #define SCENE_MINES 4
+#define SCENE_WAREHOUSE 5
 #define SCENE_NEW_HANCLINGTON SCENE_CITY
 
 static inline const char *scene_id_name(int scene_id) {
@@ -20,6 +21,7 @@ static inline const char *scene_id_name(int scene_id) {
         case SCENE_VOXWORLD: return "SCENE_VOXWORLD";
         case SCENE_CITY: return "SCENE_NEW_HANCLINGTON";
         case SCENE_MINES: return "SCENE_MINES";
+        case SCENE_WAREHOUSE: return "WAREHOUSE";
         default: return "SCENE_UNKNOWN";
     }
 }


### PR DESCRIPTION
### Motivation
- Provide a new, distinct playspace with an industrial/warehouse staging vibe that is selectable from the lobby and usable for movement/combat testing. 
- Keep changes surgical and consistent with existing construct renderer, scene system, and telecrystal/portal behavior. 
- Use deterministic, hard-coded geometry for predictable collision and navigation.

### Description
- Added a new scene id `SCENE_WAREHOUSE` and made `scene_id_name(...)` return a readable `"WAREHOUSE"` label by updating `packages/common/protocol.h`.
- Integrated `Warehouse` into the lobby options table and resolver (`LOBBY_SCENE_OPTIONS` and `lobby_resolve_scene_id`) so strings `"WAREHOUSE"` and `"SCENE_WAREHOUSE"` resolve correctly in `apps/lobby/src/main.c`.
- Implemented a hardcoded collision geometry set `map_geo_warehouse` in `packages/common/physics.h` representing an interior hall + loading-yard, with repeating support columns, segmented loading-door wall, overhead beam strips, several low cover crates, a catwalk ledge illusion, spawn offsets, and safe bounds/kill-Y checks.
- Wired the warehouse into physics scene switching (`phys_set_scene`, `scene_spawn_point`, `scene_safety_check`, and `phys_respawn`) and added a lightweight 2D overlay label and subtle scene-specific tinting in `apps/lobby/src/main.c` to match the construct aesthetic.
- Files changed: `packages/common/protocol.h`, `packages/common/physics.h`, `apps/lobby/src/main.c`.

### Testing
- Attempted `make` build to validate compilation, but it failed in this environment due to missing system SDL2 headers/libs (`SDL2/SDL.h`, `SDL2/SDL_opengl.h`), so a full build/run validation could not be performed here (make aborted with header errors).
- Tried `./run_tests` and `bash run_tests`, both failed in this environment (`Permission denied` / non-executable binary), and `make test` is not available in the Makefile, so no automated test suite ran successfully here.
- Performed local static integration checks (code edits, resolver entries, spawn/safety logic), and committed the changes; no runtime regressions to existing scenes were introduced intentionally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aa41b17d08327b94a77b030b32ae6)