### PR TITLE
Add DOCKS scene with telecrystal travel, geometry, and docs

### DIFF
--- a/docs2/specs/DOCKS_SCENE_SPEC.md
+++ b/docs2/specs/DOCKS_SCENE_SPEC.md
@@ -1,0 +1,44 @@
+# DOCKS Scene Spec
+
+## Overview
+The Docks is a separate traversable scene (`SCENE_DOCKS`) that represents the industrial waterfront logistics district of New Hanclington.
+
+## Purpose
+- Establish economy flow in-world: **mines -> rail -> warehouses -> ships**.
+- Provide a large combat/traversal sandbox distinct from Mines.
+- Provide expansion hooks for ferry travel, customs, and future harbor content.
+
+## Travel Integration
+- Telecrystal: `TOWN -> DOCKS` from city waterfront.
+- Telecrystal: `DOCKS -> TOWN` from docks arrival yard.
+- Cast profile mirrors Mines pattern (`~1000ms total`, `~600ms commit`; return uses `900/500`).
+
+## Spawn Points
+- Arrival cluster near crystal yard (negative X, low Z lane).
+- Return landing in town waterfront district near the dock gate.
+
+## Geometry Zones (v1)
+1. **Crystal Yard** (safe-ish arrival apron)
+2. **Freight Spine** (parallel rail lanes + railcar cover)
+3. **Warehouse Apron** (large warehouse belt and loading lanes)
+4. **Container Maze** (stacked close-cover route)
+5. **Quayside** (waterfront edge with ship silhouettes + cranes)
+6. **Ferry Stub** (future gate/expansion marker)
+
+## Visual Language
+- Neon-brutalist industrial silhouettes.
+- Large matte-black massing with selective cyan/amber accents.
+- Readability first: collision silhouette over micro-detail.
+
+## Future Hooks
+- Harbor events and dynamic cargo objectives.
+- Fishing/harvest nodes.
+- Ferry travel and customs gate unlock.
+- Faction NPCs and dock patrol encounters.
+
+## Acceptance Criteria
+- Town <-> Docks teleports function reliably.
+- `SCENE_DOCKS` loads as an isolated scene.
+- Spawn orientation and player state reset are stable on teleport.
+- No kill-volume softlocks or out-of-bounds fall-through.
+- Mines route remains unaffected.

--- a/docs2/specs/SCENE_REGISTRY_SPEC.md
+++ b/docs2/specs/SCENE_REGISTRY_SPEC.md
@@ -1,0 +1,18 @@
+# Scene Registry Spec
+
+Canonical scene IDs and aliases.
+
+| Scene ID Constant | Numeric | Canonical Name | Accepted aliases |
+|---|---:|---|---|
+| `SCENE_GARAGE_OSAKA` | 0 | GARAGE_OSAKA | `GARAGE_OSAKA` |
+| `SCENE_STADIUM` | 1 | STADIUM | `STADIUM` |
+| `SCENE_VOXWORLD` | 2 | VOXWORLD | `VOXWORLD` |
+| `SCENE_CITY` (`SCENE_NEW_HANCLINGTON`) | 3 | NEW_HANCLINGTON | `NEW_HANCLINGTON_MOCKUP`, `NEW_HANCLINGTON`, `SCENE_CITY` |
+| `SCENE_MINES` | 4 | MINES | `MINES`, `SCENE_MINES` |
+| `SCENE_WAREHOUSE` | 5 | WAREHOUSE | `WAREHOUSE`, `SCENE_WAREHOUSE` |
+| `SCENE_DOCKS` | 6 | DOCKS | `DOCKS`, `SCENE_DOCKS` |
+
+Implementation surfaces:
+- `scene_id_name(scene_id)`
+- `lobby_resolve_scene_id(scene_id_string)`
+- `scene_load(scene_id)` + `phys_set_scene(scene_id)`

--- a/docs2/specs/TELECRYSTAL_NETWORK_SPEC.md
+++ b/docs2/specs/TELECRYSTAL_NETWORK_SPEC.md
@@ -1,0 +1,16 @@
+# Telecrystal Network Spec
+
+Canonical registry for scene-to-scene telecrystal travel.
+
+| id | source_scene | position (x,y,z) | radius | prompt | cast total/commit | target_scene | spawn (x,y,z) | yaw/pitch | target_name |
+|---|---|---|---:|---|---|---|---|---|---|
+| `TELECRYSTAL_ID_TOWN_TO_MINES` | `SCENE_CITY` | `(270,0,60)` | 14 | `G: TELEPORT MINES` | `1000/600` | `SCENE_MINES` | `(0,0,-92)` | `0/0` | `MINES` |
+| `TELECRYSTAL_ID_MINES_RETURN_TOWN` | `SCENE_MINES` | `(0,0,-92)` | 10 | `G: RETURN TOWN` | `900/500` | `SCENE_CITY` | `(270,0,60)` | `180/0` | `TOWN` |
+| `TELECRYSTAL_ID_MINES_STUB_CRYSTAL` | `SCENE_MINES` | `(0,0,178)` | 10 | `G: CRYSTAL SHUNT` | `900/500` | `SCENE_MINES` | `(0,0,44)` | `180/0` | `MINE SPLIT` |
+| `TELECRYSTAL_ID_MINES_SPLIT_CRYSTAL` | `SCENE_MINES` | `(0,0,44)` | 8 | `G: RETURN ENTRY` | `900/500` | `SCENE_MINES` | `(0,0,-92)` | `180/0` | `MINE ENTRY` |
+| `TELECRYSTAL_ID_TOWN_TO_DOCKS` | `SCENE_CITY` | `(308,0,246)` | 14 | `G: TELEPORT DOCKS` | `1000/600` | `SCENE_DOCKS` | `(-178,0,-168)` | `95/0` | `DOCKS` |
+| `TELECRYSTAL_ID_DOCKS_RETURN_TOWN` | `SCENE_DOCKS` | `(-178,0,-168)` | 11 | `G: RETURN TOWN` | `900/500` | `SCENE_CITY` | `(300,0,238)` | `210/0` | `TOWN` |
+
+Notes:
+- Use `SDL_SCANCODE_G` as interaction input.
+- `cast_cancel_on_leave_ring = 1` for all travel links.

--- a/docs2/tasks/DOCKS_IMPLEMENTATION_PLAN.md
+++ b/docs2/tasks/DOCKS_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,33 @@
+# Docks Implementation Plan
+
+## Phase 1: Scene Registration
+- [x] Add `SCENE_DOCKS` to protocol scene constants.
+- [x] Update scene name resolver to return `DOCKS`.
+- [x] Add lobby resolver aliases `DOCKS` and `SCENE_DOCKS`.
+
+## Phase 2: Telecrystal Links
+- [x] Add `TELECRYSTAL_ID_TOWN_TO_DOCKS`.
+- [x] Add `TELECRYSTAL_ID_DOCKS_RETURN_TOWN`.
+- [x] Wire travel data in `TELECRYSTAL_DEFS`.
+
+## Phase 3: Scene Geometry + Collision
+- [x] Add `map_geo_docks` with large industrial district silhouettes.
+- [x] Register `SCENE_DOCKS` branch in `phys_set_scene`.
+- [x] Add docks spawn points and safety bounds.
+
+## Phase 4: Runtime Hooks
+- [x] Add `telecrystal_spawn_docks_mobs()` extension hook.
+- [x] Trigger docks hook from `world_teleport_player_to_scene()`.
+- [x] Keep projectile clear + camera sync behavior on teleport.
+
+## Phase 5: UX + Debug
+- [x] Add docks scene option in lobby scene picker.
+- [x] Add route labels for major docks lanes.
+- [x] Keep telecrystal drawing active for docks scene.
+
+## Validation Checklist
+- [ ] Town -> Mines still works.
+- [ ] Town -> Docks works.
+- [ ] Docks -> Town return works.
+- [ ] Spawn yaw/pitch and movement flags reset on travel.
+- [ ] `local_state.scene_id` and `player.scene_id` stay aligned.

--- a/packages/common/physics.h
+++ b/packages/common/physics.h
@@ -206,6 +206,52 @@ static const Box map_geo_warehouse[] = {
     // Back-wall catwalk illusion ledge
     {0.0f, 24.0f, -82.0f, 144.0f, 2.0f, 12.0f}
 };
+
+static const Box map_geo_docks[] = {
+    {0.0f, -2.0f, 32.0f, 520.0f, 4.0f, 560.0f},
+    {0.0f, 30.0f, -248.0f, 520.0f, 60.0f, 10.0f},
+    {0.0f, 30.0f, 312.0f, 520.0f, 60.0f, 10.0f},
+    {-258.0f, 30.0f, 32.0f, 10.0f, 60.0f, 560.0f},
+    {258.0f, 30.0f, 32.0f, 10.0f, 60.0f, 560.0f},
+
+    {-178.0f, 1.0f, -168.0f, 74.0f, 2.0f, 74.0f},
+    {-178.0f, 5.0f, -130.0f, 74.0f, 10.0f, 4.0f},
+
+    {-86.0f, 0.5f, 22.0f, 8.0f, 1.0f, 468.0f},
+    {-66.0f, 0.5f, 22.0f, 8.0f, 1.0f, 468.0f},
+    {-46.0f, 0.5f, 22.0f, 8.0f, 1.0f, 468.0f},
+    {-76.0f, 4.0f, -34.0f, 20.0f, 8.0f, 48.0f},
+    {-76.0f, 4.0f, 54.0f, 20.0f, 8.0f, 48.0f},
+    {-76.0f, 4.0f, 138.0f, 20.0f, 8.0f, 44.0f},
+
+    {126.0f, 26.0f, -88.0f, 148.0f, 52.0f, 92.0f},
+    {126.0f, 26.0f, 26.0f, 148.0f, 52.0f, 92.0f},
+    {126.0f, 26.0f, 140.0f, 148.0f, 52.0f, 92.0f},
+    {56.0f, 7.0f, -30.0f, 8.0f, 14.0f, 260.0f},
+
+    {-2.0f, 4.0f, -18.0f, 42.0f, 8.0f, 16.0f},
+    {22.0f, 8.0f, -18.0f, 20.0f, 16.0f, 16.0f},
+    {-24.0f, 4.0f, 22.0f, 42.0f, 8.0f, 16.0f},
+    {6.0f, 8.0f, 22.0f, 20.0f, 16.0f, 16.0f},
+    {-4.0f, 4.0f, 62.0f, 42.0f, 8.0f, 16.0f},
+    {20.0f, 8.0f, 62.0f, 20.0f, 16.0f, 16.0f},
+    {-28.0f, 4.0f, 104.0f, 42.0f, 8.0f, 16.0f},
+
+    {-12.0f, 1.0f, 232.0f, 470.0f, 2.0f, 44.0f},
+    {-12.0f, 6.0f, 252.0f, 470.0f, 10.0f, 6.0f},
+    {-162.0f, 20.0f, 286.0f, 132.0f, 40.0f, 34.0f},
+    {92.0f, 22.0f, 286.0f, 168.0f, 44.0f, 38.0f},
+    {-198.0f, 28.0f, 256.0f, 8.0f, 56.0f, 8.0f},
+    {-150.0f, 28.0f, 256.0f, 8.0f, 56.0f, 8.0f},
+    {44.0f, 30.0f, 256.0f, 8.0f, 60.0f, 8.0f},
+    {96.0f, 30.0f, 256.0f, 8.0f, 60.0f, 8.0f},
+
+    {-206.0f, 10.0f, 126.0f, 22.0f, 20.0f, 22.0f},
+    {-178.0f, 8.0f, 86.0f, 18.0f, 16.0f, 18.0f},
+    {-202.0f, 8.0f, 54.0f, 20.0f, 16.0f, 16.0f},
+    {216.0f, 6.0f, 236.0f, 48.0f, 12.0f, 24.0f},
+    {238.0f, 14.0f, 254.0f, 6.0f, 28.0f, 6.0f}
+};
 #define CITY_MAX_BOXES 2048
 static Box map_geo_voxworld[CITY_MAX_BOXES];
 static int map_geo_voxworld_count = 0;
@@ -231,6 +277,9 @@ static int map_count = 0;
 #define WAREHOUSE_KILL_Y -70.0f
 #define WAREHOUSE_BOUNDS_X 184.0f
 #define WAREHOUSE_BOUNDS_Z 236.0f
+#define DOCKS_KILL_Y -80.0f
+#define DOCKS_BOUNDS_X 260.0f
+#define DOCKS_BOUNDS_Z 300.0f
 #define VOXWORLD_SEED 1337
 
 #define GARAGE_PORTAL_X 0.0f
@@ -327,6 +376,9 @@ static inline void phys_set_scene(int scene_id) {
     } else if (scene_id == SCENE_WAREHOUSE) {
         map_geo = map_geo_warehouse;
         map_count = (int)(sizeof(map_geo_warehouse) / sizeof(Box));
+    } else if (scene_id == SCENE_DOCKS) {
+        map_geo = map_geo_docks;
+        map_count = (int)(sizeof(map_geo_docks) / sizeof(Box));
     } else {
         map_geo = map_geo_stadium;
         map_count = (int)(sizeof(map_geo_stadium) / sizeof(Box));
@@ -368,6 +420,14 @@ static inline void scene_spawn_point(int scene_id, int slot, float *out_x, float
         *out_x = offsets[idx];
         *out_y = 0.0f;
         *out_z = -62.0f;
+        return;
+    }
+    if (scene_id == SCENE_DOCKS) {
+        float offsets[] = {-190.0f, -182.0f, -174.0f, -166.0f, -158.0f};
+        int idx = slot % 5;
+        *out_x = offsets[idx];
+        *out_y = 0.0f;
+        *out_z = -168.0f;
         return;
     }
     if (slot % 2 == 0) {
@@ -434,6 +494,14 @@ static inline void scene_safety_check(PlayerState *p) {
         if (p->y < WAREHOUSE_KILL_Y ||
             p->x < -WAREHOUSE_BOUNDS_X || p->x > WAREHOUSE_BOUNDS_X ||
             p->z < -WAREHOUSE_BOUNDS_Z || p->z > WAREHOUSE_BOUNDS_Z) {
+            scene_force_spawn(p);
+        }
+        return;
+    }
+    if (p->scene_id == SCENE_DOCKS) {
+        if (p->y < DOCKS_KILL_Y ||
+            p->x < -DOCKS_BOUNDS_X || p->x > DOCKS_BOUNDS_X ||
+            p->z < -DOCKS_BOUNDS_Z || p->z > DOCKS_BOUNDS_Z) {
             scene_force_spawn(p);
         }
     }

--- a/packages/common/protocol.h
+++ b/packages/common/protocol.h
@@ -12,6 +12,7 @@
 #define SCENE_CITY 3
 #define SCENE_MINES 4
 #define SCENE_WAREHOUSE 5
+#define SCENE_DOCKS 6
 #define SCENE_NEW_HANCLINGTON SCENE_CITY
 
 static inline const char *scene_id_name(int scene_id) {
@@ -22,6 +23,7 @@ static inline const char *scene_id_name(int scene_id) {
         case SCENE_CITY: return "SCENE_NEW_HANCLINGTON";
         case SCENE_MINES: return "SCENE_MINES";
         case SCENE_WAREHOUSE: return "WAREHOUSE";
+        case SCENE_DOCKS: return "DOCKS";
         default: return "SCENE_UNKNOWN";
     }
 }


### PR DESCRIPTION
### Motivation
- Introduce a new separate `SCENE_DOCKS` area (industrial waterfront) reusing the existing telecrystal travel pattern used by `MINES`.
- Keep telecrystal behavior and scene-aware player/collision logic consistent while providing a hook for future docks content.
- Ship a compact design spec and rollout plan so the scene can be iterated on without drifting implementation details.

### Description
- Added `SCENE_DOCKS` and canonical name support in `packages/common/protocol.h`.
- Implemented `map_geo_docks` in `packages/common/physics.h` and wired it into `phys_set_scene`, spawn points (`scene_spawn_point`) and safety bounds (`scene_safety_check`).
- Added Town↔Docks telecrystal entries (`TELECRYSTAL_ID_TOWN_TO_DOCKS`, `TELECRYSTAL_ID_DOCKS_RETURN_TOWN`) to `TELECRYSTAL_DEFS` in `apps/lobby/src/main.c` with matching cast/commit timings and spawn/yaw settings.
- Added a docks content-init hook `telecrystal_spawn_docks_mobs()` and call site in `world_teleport_player_to_scene` to mirror the mines flow.
- Integrated debug/UI elements: lobby scene option and resolver aliases for `DOCKS`, route label overlay `docks_draw_route_labels_2d`, and telecrystal ring color support for `SCENE_DOCKS`.
- Added documentation artifacts: `docs2/specs/DOCKS_SCENE_SPEC.md`, `TELECRYSTAL_NETWORK_SPEC.md`, `SCENE_REGISTRY_SPEC.md`, and `docs2/tasks/DOCKS_IMPLEMENTATION_PLAN.md` describing layout, telecrystal registry, and phased tasks.

### Testing
- Ran `make server` which built successfully (`bin/shank_server`) in this environment.
- Ran `make lobby` which failed to build due to missing SDL2 headers/libs in the container (environment limitation), not code errors introduced by this change.
- Attempted `run_tests` but the test runner was not executable in this environment, so automated test suite could not be executed here.
- Committed the changes and verified source diffs (`apps/lobby/src/main.c`, `packages/common/physics.h`, `packages/common/protocol.h`) and added the docs files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ccb52aae08327929f36bf2af0eccb)