### PR TITLE
Add Giza Plateau world scene (selectable, physics, telecrystals)

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -122,6 +122,8 @@ static char travel_overlay_text[64] = "TRAVELING...";
 #define TELECRYSTAL_ID_MINES_SPLIT_CRYSTAL 4
 #define TELECRYSTAL_ID_TOWN_TO_DOCKS 5
 #define TELECRYSTAL_ID_DOCKS_RETURN_TOWN 6
+#define TELECRYSTAL_ID_TOWN_TO_GIZA 7
+#define TELECRYSTAL_ID_GIZA_RETURN_TOWN 8
 static const TelecrystalDef TELECRYSTAL_DEFS[] = {
     {
         TELECRYSTAL_ID_TOWN_TO_MINES,
@@ -216,6 +218,38 @@ static const TelecrystalDef TELECRYSTAL_DEFS[] = {
         SCENE_CITY,
         300.0f, 0.0f, 238.0f,
         210.0f,
+        0.0f,
+        "TOWN"
+    },
+    {
+        TELECRYSTAL_ID_TOWN_TO_GIZA,
+        SCENE_CITY,
+        238.0f, 0.0f, 304.0f,
+        15.0f,
+        "G: TELEPORT GIZA",
+        SDL_SCANCODE_G,
+        1000,
+        600,
+        1,
+        SCENE_GIZA_PLATEAU,
+        130.0f, 0.0f, 1180.0f,
+        348.0f,
+        0.0f,
+        "GIZA PLATEAU"
+    },
+    {
+        TELECRYSTAL_ID_GIZA_RETURN_TOWN,
+        SCENE_GIZA_PLATEAU,
+        130.0f, 0.0f, 1180.0f,
+        12.0f,
+        "G: RETURN TOWN",
+        SDL_SCANCODE_G,
+        900,
+        500,
+        1,
+        SCENE_CITY,
+        238.0f, 0.0f, 304.0f,
+        182.0f,
         0.0f,
         "TOWN"
     }
@@ -637,6 +671,46 @@ static void docks_draw_route_labels_2d(PlayerState *render_p) {
     glEnable(GL_DEPTH_TEST);
 }
 
+static void giza_draw_route_labels_2d(PlayerState *render_p) {
+    if (!crisis_mock_state.labels_on) return;
+    if (render_p->scene_id != SCENE_GIZA_PLATEAU) return;
+
+    static const struct {
+        const char *text;
+        float x, y, z;
+        float r, g, b;
+    } labels[] = {
+        {"SOUTH APRON", 120.0f, 8.0f, 1180.0f, 1.00f, 0.86f, 0.42f},
+        {"GREAT PYRAMID", 520.0f, 214.0f, -460.0f, 1.00f, 0.95f, 0.55f},
+        {"KHAFRE", -180.0f, 168.0f, -700.0f, 0.96f, 0.82f, 0.44f},
+        {"MENKAURE", -900.0f, 110.0f, -1080.0f, 0.90f, 0.74f, 0.40f},
+        {"SPHINX", 300.0f, 24.0f, -930.0f, 1.00f, 0.62f, 0.28f},
+        {"CAUSEWAY", 110.0f, 10.0f, -858.0f, 0.44f, 0.92f, 1.00f}
+    };
+
+    GLdouble model[16], proj[16];
+    GLint view[4];
+    glGetDoublev(GL_MODELVIEW_MATRIX, model);
+    glGetDoublev(GL_PROJECTION_MATRIX, proj);
+    glGetIntegerv(GL_VIEWPORT, view);
+
+    glDisable(GL_DEPTH_TEST);
+    glMatrixMode(GL_PROJECTION); glPushMatrix(); glLoadIdentity(); glOrtho(0, 1280, 0, 720, -1, 1);
+    glMatrixMode(GL_MODELVIEW); glPushMatrix(); glLoadIdentity();
+
+    for (size_t i = 0; i < sizeof(labels) / sizeof(labels[0]); i++) {
+        float sx = 0.0f, sy = 0.0f;
+        if (!project_world_to_screen(labels[i].x, labels[i].y, labels[i].z, model, proj, view, &sx, &sy)) continue;
+        if (sx < -20.0f || sx > 1300.0f || sy < -20.0f || sy > 740.0f) continue;
+        glColor3f(labels[i].r, labels[i].g, labels[i].b);
+        draw_string(labels[i].text, sx - 28.0f, sy - 8.0f, 2);
+    }
+
+    glMatrixMode(GL_PROJECTION); glPopMatrix();
+    glMatrixMode(GL_MODELVIEW); glPopMatrix();
+    glEnable(GL_DEPTH_TEST);
+}
+
 typedef enum {
     LOBBY_DEMO = 0,
     LOBBY_BATTLE,
@@ -661,7 +735,8 @@ static const LobbySceneOption LOBBY_SCENE_OPTIONS[] = {
     {"New Hanclington", "NEW_HANCLINGTON_MOCKUP", SCENE_NEW_HANCLINGTON},
     {"Warehouse", "WAREHOUSE", SCENE_WAREHOUSE},
     {"Mines", "MINES", SCENE_MINES},
-    {"Docks", "DOCKS", SCENE_DOCKS}
+    {"Docks", "DOCKS", SCENE_DOCKS},
+    {"Giza Plateau", "GIZA_PLATEAU", SCENE_GIZA_PLATEAU}
 };
 
 static int lobby_scene_selection = 0;
@@ -748,6 +823,8 @@ static int lobby_resolve_scene_id(const char *scene_id) {
     if (strcmp(scene_id, "SCENE_MINES") == 0) return SCENE_MINES;
     if (strcmp(scene_id, "DOCKS") == 0) return SCENE_DOCKS;
     if (strcmp(scene_id, "SCENE_DOCKS") == 0) return SCENE_DOCKS;
+    if (strcmp(scene_id, "GIZA_PLATEAU") == 0) return SCENE_GIZA_PLATEAU;
+    if (strcmp(scene_id, "SCENE_GIZA_PLATEAU") == 0) return SCENE_GIZA_PLATEAU;
     return -1;
 }
 
@@ -1168,6 +1245,20 @@ void draw_map() {
                 nr = 0.26f;
                 ng = 0.65f;
                 nb = 0.52f;
+            }
+        } else if (local_state.scene_id == SCENE_GIZA_PLATEAU) {
+            float ridge = 0.5f + 0.5f * sinf((b.x * 0.0025f) + (b.z * 0.0020f));
+            nr = 0.66f + 0.18f * ridge;
+            ng = 0.54f + 0.16f * ridge;
+            nb = 0.28f + 0.10f * ridge;
+            if (b.h > 30.0f && b.w > 200.0f && b.d > 200.0f) {
+                nr += 0.07f;
+                ng += 0.05f;
+            }
+            if (b.h <= 3.0f) {
+                nr -= 0.10f;
+                ng -= 0.08f;
+                nb -= 0.05f;
             }
         }
 
@@ -1637,6 +1728,8 @@ static void telecrystal_ring_color(const TelecrystalDef *def, int in_range, floa
         glColor3f(0.38f, 0.72f + pulse * 0.3f, 1.0f);
     } else if (def->target_scene_id == SCENE_DOCKS) {
         glColor3f(0.18f, 0.80f + pulse * 0.18f, 0.95f);
+    } else if (def->target_scene_id == SCENE_GIZA_PLATEAU) {
+        glColor3f(0.95f, 0.78f + pulse * 0.14f, 0.28f);
     } else if (def->target_scene_id == SCENE_CITY) {
         glColor3f(1.0f, 0.58f + pulse * 0.25f, 0.25f);
     } else {
@@ -1800,7 +1893,7 @@ void draw_scene(PlayerState *render_p) {
         town_render_world(&crisis_mock_state);
         draw_world_telecrystals(render_p);
     } else {
-        if (render_p->scene_id == SCENE_MINES || render_p->scene_id == SCENE_DOCKS) draw_world_telecrystals(render_p);
+        if (render_p->scene_id == SCENE_MINES || render_p->scene_id == SCENE_DOCKS || render_p->scene_id == SCENE_GIZA_PLATEAU) draw_world_telecrystals(render_p);
         draw_grid(); 
         update_and_draw_trails();
         draw_map();
@@ -1831,6 +1924,9 @@ void draw_scene(PlayerState *render_p) {
     } else if (render_p->scene_id == SCENE_DOCKS) {
         docks_draw_route_labels_2d(render_p);
         draw_string("DOCKS DISTRICT / FREIGHT QUAY", 42.0f, 92.0f, 4);
+    } else if (render_p->scene_id == SCENE_GIZA_PLATEAU) {
+        giza_draw_route_labels_2d(render_p);
+        draw_string("GIZA PLATEAU / MONUMENTAL DESERT DISTRICT", 42.0f, 92.0f, 4);
     } else if (render_p->scene_id == SCENE_WAREHOUSE) {
         draw_string("WAREHOUSE FLOOR / LOADING YARD", 42.0f, 92.0f, 4);
     }

--- a/packages/common/physics.h
+++ b/packages/common/physics.h
@@ -252,6 +252,104 @@ static const Box map_geo_docks[] = {
     {216.0f, 6.0f, 236.0f, 48.0f, 12.0f, 24.0f},
     {238.0f, 14.0f, 254.0f, 6.0f, 28.0f, 6.0f}
 };
+
+static const Box map_geo_giza[] = {
+    // FAR DESERT BASE + SUBTLE UNDULATION
+    {0.0f, -2.0f, 0.0f, 5200.0f, 4.0f, 5200.0f},
+    {420.0f, -0.6f, 820.0f, 1200.0f, 2.0f, 720.0f},
+    {-760.0f, -0.4f, 540.0f, 980.0f, 2.0f, 640.0f},
+    {860.0f, -0.5f, -220.0f, 920.0f, 2.0f, 720.0f},
+    {-980.0f, -0.7f, -520.0f, 1000.0f, 2.0f, 840.0f},
+    {40.0f, -0.3f, -1300.0f, 1800.0f, 2.0f, 760.0f},
+
+    // SOUTH APRON / SPAWN FIELD
+    {120.0f, 0.6f, 1180.0f, 980.0f, 1.2f, 680.0f},
+    {-540.0f, 0.4f, 1220.0f, 760.0f, 0.8f, 420.0f},
+    {730.0f, 0.4f, 1240.0f, 760.0f, 0.8f, 420.0f},
+
+    // ESCARPMENT EDGE / WORLD FRAME
+    {0.0f, 70.0f, -2500.0f, 5200.0f, 140.0f, 26.0f},
+    {0.0f, 70.0f, 2500.0f, 5200.0f, 140.0f, 26.0f},
+    {-2500.0f, 70.0f, 0.0f, 26.0f, 140.0f, 5200.0f},
+    {2500.0f, 70.0f, 0.0f, 26.0f, 140.0f, 5200.0f},
+    {-1620.0f, 24.0f, -1380.0f, 780.0f, 48.0f, 180.0f},
+    {1480.0f, 22.0f, -1460.0f, 820.0f, 44.0f, 180.0f},
+    {-1810.0f, 18.0f, 0.0f, 260.0f, 36.0f, 1420.0f},
+    {1760.0f, 20.0f, 220.0f, 300.0f, 40.0f, 1500.0f},
+
+    // PLATEAU SHELVES / RIDGES
+    {200.0f, 5.0f, -440.0f, 2200.0f, 10.0f, 980.0f},
+    {-420.0f, 8.0f, -760.0f, 1480.0f, 16.0f, 840.0f},
+    {-950.0f, 10.0f, -1120.0f, 820.0f, 20.0f, 620.0f},
+    {420.0f, 3.5f, -900.0f, 1360.0f, 7.0f, 320.0f},
+    {-260.0f, 2.5f, -1200.0f, 740.0f, 5.0f, 220.0f},
+    {980.0f, 3.0f, -640.0f, 640.0f, 6.0f, 220.0f},
+
+    // KHUFU MASS (DOMINANT)
+    {520.0f, 45.0f, -460.0f, 600.0f, 90.0f, 600.0f},
+    {520.0f, 92.0f, -460.0f, 470.0f, 78.0f, 470.0f},
+    {520.0f, 132.0f, -460.0f, 360.0f, 62.0f, 360.0f},
+    {520.0f, 163.0f, -460.0f, 260.0f, 48.0f, 260.0f},
+    {520.0f, 186.0f, -460.0f, 168.0f, 34.0f, 168.0f},
+    {520.0f, 204.0f, -460.0f, 90.0f, 20.0f, 90.0f},
+
+    // KHAFRE MASS (HIGHER GROUND, SLIGHTLY SMALLER)
+    {-180.0f, 15.0f, -700.0f, 760.0f, 30.0f, 760.0f},
+    {-180.0f, 53.0f, -700.0f, 500.0f, 76.0f, 500.0f},
+    {-180.0f, 92.0f, -700.0f, 390.0f, 62.0f, 390.0f},
+    {-180.0f, 123.0f, -700.0f, 300.0f, 46.0f, 300.0f},
+    {-180.0f, 145.0f, -700.0f, 210.0f, 34.0f, 210.0f},
+    {-180.0f, 160.0f, -700.0f, 120.0f, 20.0f, 120.0f},
+
+    // MENKAURE MASS (SMALLER, FAR SOUTHWEST)
+    {-900.0f, 14.0f, -1080.0f, 560.0f, 28.0f, 560.0f},
+    {-900.0f, 40.0f, -1080.0f, 320.0f, 52.0f, 320.0f},
+    {-900.0f, 68.0f, -1080.0f, 240.0f, 40.0f, 240.0f},
+    {-900.0f, 88.0f, -1080.0f, 170.0f, 30.0f, 170.0f},
+    {-900.0f, 100.0f, -1080.0f, 90.0f, 18.0f, 90.0f},
+
+    // SPHINX / VALLEY BAND (EAST-SOUTHEAST OF KHAFRE)
+    {220.0f, 5.0f, -980.0f, 420.0f, 10.0f, 220.0f},
+    {300.0f, 12.0f, -930.0f, 170.0f, 24.0f, 60.0f},
+    {250.0f, 16.0f, -950.0f, 60.0f, 10.0f, 90.0f},
+    {338.0f, 17.0f, -930.0f, 38.0f, 6.0f, 40.0f},
+    {362.0f, 20.0f, -930.0f, 22.0f, 4.0f, 16.0f},
+    {160.0f, 8.0f, -1035.0f, 180.0f, 16.0f, 64.0f},
+    {70.0f, 6.0f, -1080.0f, 150.0f, 12.0f, 120.0f},
+
+    // CAUSEWAY LOGIC (KHAFRE -> SPHINX AXIS)
+    {-20.0f, 6.2f, -800.0f, 420.0f, 1.6f, 26.0f},
+    {110.0f, 6.4f, -858.0f, 320.0f, 1.8f, 24.0f},
+    {205.0f, 6.6f, -914.0f, 240.0f, 2.0f, 22.0f},
+    {-20.0f, 5.2f, -824.0f, 420.0f, 0.8f, 16.0f},
+    {110.0f, 5.2f, -880.0f, 320.0f, 0.8f, 14.0f},
+    {205.0f, 5.2f, -935.0f, 240.0f, 0.8f, 14.0f},
+
+    // MASTABA / RUIN FIELDS (SPARSE)
+    {760.0f, 3.0f, -690.0f, 70.0f, 6.0f, 38.0f},
+    {680.0f, 3.0f, -730.0f, 62.0f, 6.0f, 34.0f},
+    {600.0f, 2.5f, -760.0f, 56.0f, 5.0f, 30.0f},
+    {530.0f, 2.2f, -780.0f, 44.0f, 4.4f, 28.0f},
+    {430.0f, 2.8f, -760.0f, 64.0f, 5.6f, 30.0f},
+    {340.0f, 3.0f, -740.0f, 74.0f, 6.0f, 34.0f},
+    {-520.0f, 2.6f, -860.0f, 58.0f, 5.2f, 30.0f},
+    {-620.0f, 2.6f, -920.0f, 62.0f, 5.2f, 32.0f},
+    {-710.0f, 2.8f, -980.0f, 70.0f, 5.6f, 36.0f},
+    {-260.0f, 2.4f, -1020.0f, 56.0f, 4.8f, 28.0f},
+    {-140.0f, 2.4f, -1040.0f, 52.0f, 4.8f, 26.0f},
+    {-20.0f, 2.4f, -1060.0f, 56.0f, 4.8f, 30.0f},
+    {-1020.0f, 2.6f, -860.0f, 60.0f, 5.2f, 34.0f},
+    {-1140.0f, 2.8f, -930.0f, 72.0f, 5.6f, 38.0f},
+    {-1220.0f, 2.6f, -1010.0f, 60.0f, 5.2f, 34.0f},
+    {-1080.0f, 2.2f, -1160.0f, 48.0f, 4.4f, 28.0f},
+    {-960.0f, 2.0f, -1220.0f, 42.0f, 4.0f, 24.0f},
+    {-820.0f, 2.2f, -1260.0f, 50.0f, 4.4f, 28.0f},
+
+    // LANDING TERRACES / OVERLOOK TOUCHES
+    {560.0f, 4.0f, 220.0f, 260.0f, 8.0f, 110.0f},
+    {-340.0f, 6.0f, 120.0f, 300.0f, 12.0f, 130.0f},
+    {1120.0f, 22.0f, -260.0f, 240.0f, 44.0f, 140.0f}
+};
 #define CITY_MAX_BOXES 2048
 static Box map_geo_voxworld[CITY_MAX_BOXES];
 static int map_geo_voxworld_count = 0;
@@ -280,6 +378,9 @@ static int map_count = 0;
 #define DOCKS_KILL_Y -80.0f
 #define DOCKS_BOUNDS_X 260.0f
 #define DOCKS_BOUNDS_Z 300.0f
+#define GIZA_KILL_Y -140.0f
+#define GIZA_BOUNDS_X 2480.0f
+#define GIZA_BOUNDS_Z 2480.0f
 #define VOXWORLD_SEED 1337
 
 #define GARAGE_PORTAL_X 0.0f
@@ -379,6 +480,9 @@ static inline void phys_set_scene(int scene_id) {
     } else if (scene_id == SCENE_DOCKS) {
         map_geo = map_geo_docks;
         map_count = (int)(sizeof(map_geo_docks) / sizeof(Box));
+    } else if (scene_id == SCENE_GIZA_PLATEAU) {
+        map_geo = map_geo_giza;
+        map_count = (int)(sizeof(map_geo_giza) / sizeof(Box));
     } else {
         map_geo = map_geo_stadium;
         map_count = (int)(sizeof(map_geo_stadium) / sizeof(Box));
@@ -428,6 +532,14 @@ static inline void scene_spawn_point(int scene_id, int slot, float *out_x, float
         *out_x = offsets[idx];
         *out_y = 0.0f;
         *out_z = -168.0f;
+        return;
+    }
+    if (scene_id == SCENE_GIZA_PLATEAU) {
+        float offsets[] = {84.0f, 108.0f, 132.0f, 156.0f, 180.0f};
+        int idx = slot % 5;
+        *out_x = offsets[idx];
+        *out_y = 0.0f;
+        *out_z = 1180.0f;
         return;
     }
     if (slot % 2 == 0) {
@@ -502,6 +614,14 @@ static inline void scene_safety_check(PlayerState *p) {
         if (p->y < DOCKS_KILL_Y ||
             p->x < -DOCKS_BOUNDS_X || p->x > DOCKS_BOUNDS_X ||
             p->z < -DOCKS_BOUNDS_Z || p->z > DOCKS_BOUNDS_Z) {
+            scene_force_spawn(p);
+        }
+        return;
+    }
+    if (p->scene_id == SCENE_GIZA_PLATEAU) {
+        if (p->y < GIZA_KILL_Y ||
+            p->x < -GIZA_BOUNDS_X || p->x > GIZA_BOUNDS_X ||
+            p->z < -GIZA_BOUNDS_Z || p->z > GIZA_BOUNDS_Z) {
             scene_force_spawn(p);
         }
     }
@@ -803,7 +923,7 @@ void phys_respawn(PlayerState *p, unsigned int now) {
     p->active = 1; p->state = STATE_ALIVE;
     p->health = 100; p->shield = 100; p->respawn_time = 0; p->in_vehicle = 0;
     p->use_was_down = 0;
-    if (p->scene_id != SCENE_GARAGE_OSAKA && p->scene_id != SCENE_STADIUM && p->scene_id != SCENE_VOXWORLD && p->scene_id != SCENE_CITY && p->scene_id != SCENE_MINES && p->scene_id != SCENE_WAREHOUSE) {
+    if (p->scene_id != SCENE_GARAGE_OSAKA && p->scene_id != SCENE_STADIUM && p->scene_id != SCENE_VOXWORLD && p->scene_id != SCENE_CITY && p->scene_id != SCENE_MINES && p->scene_id != SCENE_WAREHOUSE && p->scene_id != SCENE_DOCKS && p->scene_id != SCENE_GIZA_PLATEAU) {
         p->scene_id = SCENE_GARAGE_OSAKA;
     }
     scene_spawn_point(p->scene_id, p->id, &p->x, &p->y, &p->z);

--- a/packages/common/protocol.h
+++ b/packages/common/protocol.h
@@ -13,6 +13,7 @@
 #define SCENE_MINES 4
 #define SCENE_WAREHOUSE 5
 #define SCENE_DOCKS 6
+#define SCENE_GIZA_PLATEAU 7
 #define SCENE_NEW_HANCLINGTON SCENE_CITY
 
 static inline const char *scene_id_name(int scene_id) {
@@ -24,6 +25,7 @@ static inline const char *scene_id_name(int scene_id) {
         case SCENE_MINES: return "SCENE_MINES";
         case SCENE_WAREHOUSE: return "WAREHOUSE";
         case SCENE_DOCKS: return "DOCKS";
+        case SCENE_GIZA_PLATEAU: return "GIZA_PLATEAU";
         default: return "SCENE_UNKNOWN";
     }
 }


### PR DESCRIPTION
### Motivation
- Provide a new large, flyable/drivable desert plateau designed for long sightlines, landmark navigation, and future helicopter gameplay. 
- Integrate the scene as a first-class multi-scene world (not a Shankpit hack) so it can be selected from the lobby and used by physics/teleport systems. 
- Favor traversal-first, low-detail large forms so monuments read from the air and performance remains predictable.

### Description
- Added a new scene id `SCENE_GIZA_PLATEAU` and string mapping (`"GIZA_PLATEAU"`) in `packages/common/protocol.h`. 
- Implemented a dedicated Box-based geometry array `map_geo_giza[]` containing the FAR DESERT base, SOUTH APRON spawn field, escarpment framing, plateau shelves, stepped pyramid masses (Khufu, Khafre, Menkaure), Sphinx/valley band, causeway elements, sparse mastaba/ruin fields, and landing terraces in `packages/common/physics.h`. 
- Wired scene routing and safety: `phys_set_scene()` selects `map_geo_giza`, added spawn logic for `SCENE_GIZA_PLATEAU`, bounds/kill checks (`GIZA_KILL_Y`, `GIZA_BOUNDS_*`), and included the scene in `phys_respawn()` validation in `packages/common/physics.h`. 
- Lobby + travel + UI integration in `apps/lobby/src/main.c`: added a lobby picker entry `"Giza Plateau"` and resolver aliases for `GIZA_PLATEAU`, two telecrystal definitions (city -> Giza and Giza -> city), telecrystal color/palette support for Giza, and a small set of long-range metadata labels (`SOUTH APRON`, `GREAT PYRAMID`, `KHAFRE`, `MENKAURE`, `SPHINX`, `CAUSEWAY`). 
- Kept the implementation performance-friendly by using large boxes and avoiding micro-detail; recommended future helicopter spawn: the South Apron near `(x≈130, z≈1180)` (flat and aligned to the pyramid field).
- Files changed: `packages/common/protocol.h`, `packages/common/physics.h`, `apps/lobby/src/main.c`.

### Testing
- Attempted an automated build with `make lobby`; build failed in this environment due to missing SDL2 headers (`SDL2/SDL.h`, `SDL2/SDL_opengl.h`), so runtime/visual verification could not be completed. (Build failure is environmental, not compiler errors from the changes.)
- Performed static verification by listing and inspecting the modified sources (`rg`/`sed`/`nl` outputs) to confirm symbols, scene registration, telecrystal entries, spawn coordinates, and that `phys_set_scene()` and respawn/safety logic reference `SCENE_GIZA_PLATEAU` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d426a8380883278cd6db286d83f427)