### PR TITLE
Add Giza Plateau world scene (SCENE_GIZA_PLATEAU)

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -122,6 +122,8 @@ static char travel_overlay_text[64] = "TRAVELING...";
 #define TELECRYSTAL_ID_MINES_SPLIT_CRYSTAL 4
 #define TELECRYSTAL_ID_TOWN_TO_DOCKS 5
 #define TELECRYSTAL_ID_DOCKS_RETURN_TOWN 6
+#define TELECRYSTAL_ID_TOWN_TO_GIZA 7
+#define TELECRYSTAL_ID_GIZA_RETURN_TOWN 8
 static const TelecrystalDef TELECRYSTAL_DEFS[] = {
     {
         TELECRYSTAL_ID_TOWN_TO_MINES,
@@ -216,6 +218,38 @@ static const TelecrystalDef TELECRYSTAL_DEFS[] = {
         SCENE_CITY,
         300.0f, 0.0f, 238.0f,
         210.0f,
+        0.0f,
+        "TOWN"
+    },
+    {
+        TELECRYSTAL_ID_TOWN_TO_GIZA,
+        SCENE_CITY,
+        98.0f, 0.0f, 318.0f,
+        16.0f,
+        "G: TELEPORT GIZA PLATEAU",
+        SDL_SCANCODE_G,
+        1000,
+        600,
+        1,
+        SCENE_GIZA_PLATEAU,
+        20.0f, 0.0f, -980.0f,
+        10.0f,
+        0.0f,
+        "GIZA PLATEAU"
+    },
+    {
+        TELECRYSTAL_ID_GIZA_RETURN_TOWN,
+        SCENE_GIZA_PLATEAU,
+        20.0f, 0.0f, -980.0f,
+        14.0f,
+        "G: RETURN TOWN",
+        SDL_SCANCODE_G,
+        900,
+        500,
+        1,
+        SCENE_CITY,
+        98.0f, 0.0f, 318.0f,
+        188.0f,
         0.0f,
         "TOWN"
     }
@@ -637,6 +671,46 @@ static void docks_draw_route_labels_2d(PlayerState *render_p) {
     glEnable(GL_DEPTH_TEST);
 }
 
+static void giza_draw_route_labels_2d(PlayerState *render_p) {
+    if (!crisis_mock_state.labels_on) return;
+    if (render_p->scene_id != SCENE_GIZA_PLATEAU) return;
+
+    static const struct {
+        const char *text;
+        float x, y, z;
+        float r, g, b;
+    } labels[] = {
+        {"SOUTH APRON", 20.0f, 3.0f, -980.0f, 0.95f, 0.86f, 0.42f},
+        {"GREAT PYRAMID", 520.0f, 100.0f, 540.0f, 1.00f, 0.92f, 0.42f},
+        {"KHAFRE", 120.0f, 90.0f, 140.0f, 0.96f, 0.72f, 0.35f},
+        {"MENKAURE", -420.0f, 50.0f, -400.0f, 0.88f, 0.80f, 0.54f},
+        {"SPHINX", 700.0f, 12.0f, -92.0f, 1.00f, 0.72f, 0.26f},
+        {"CAUSEWAY", 470.0f, 10.0f, 14.0f, 0.74f, 0.90f, 1.00f}
+    };
+
+    GLdouble model[16], proj[16];
+    GLint view[4];
+    glGetDoublev(GL_MODELVIEW_MATRIX, model);
+    glGetDoublev(GL_PROJECTION_MATRIX, proj);
+    glGetIntegerv(GL_VIEWPORT, view);
+
+    glDisable(GL_DEPTH_TEST);
+    glMatrixMode(GL_PROJECTION); glPushMatrix(); glLoadIdentity(); glOrtho(0, 1280, 0, 720, -1, 1);
+    glMatrixMode(GL_MODELVIEW); glPushMatrix(); glLoadIdentity();
+
+    for (size_t i = 0; i < sizeof(labels) / sizeof(labels[0]); i++) {
+        float sx = 0.0f, sy = 0.0f;
+        if (!project_world_to_screen(labels[i].x, labels[i].y, labels[i].z, model, proj, view, &sx, &sy)) continue;
+        if (sx < -20.0f || sx > 1300.0f || sy < -20.0f || sy > 740.0f) continue;
+        glColor3f(labels[i].r, labels[i].g, labels[i].b);
+        draw_string(labels[i].text, sx - 30.0f, sy - 8.0f, 2);
+    }
+
+    glMatrixMode(GL_PROJECTION); glPopMatrix();
+    glMatrixMode(GL_MODELVIEW); glPopMatrix();
+    glEnable(GL_DEPTH_TEST);
+}
+
 typedef enum {
     LOBBY_DEMO = 0,
     LOBBY_BATTLE,
@@ -661,7 +735,8 @@ static const LobbySceneOption LOBBY_SCENE_OPTIONS[] = {
     {"New Hanclington", "NEW_HANCLINGTON_MOCKUP", SCENE_NEW_HANCLINGTON},
     {"Warehouse", "WAREHOUSE", SCENE_WAREHOUSE},
     {"Mines", "MINES", SCENE_MINES},
-    {"Docks", "DOCKS", SCENE_DOCKS}
+    {"Docks", "DOCKS", SCENE_DOCKS},
+    {"Giza Plateau", "GIZA_PLATEAU", SCENE_GIZA_PLATEAU}
 };
 
 static int lobby_scene_selection = 0;
@@ -748,6 +823,8 @@ static int lobby_resolve_scene_id(const char *scene_id) {
     if (strcmp(scene_id, "SCENE_MINES") == 0) return SCENE_MINES;
     if (strcmp(scene_id, "DOCKS") == 0) return SCENE_DOCKS;
     if (strcmp(scene_id, "SCENE_DOCKS") == 0) return SCENE_DOCKS;
+    if (strcmp(scene_id, "GIZA_PLATEAU") == 0) return SCENE_GIZA_PLATEAU;
+    if (strcmp(scene_id, "SCENE_GIZA_PLATEAU") == 0) return SCENE_GIZA_PLATEAU;
     return -1;
 }
 
@@ -1131,8 +1208,8 @@ void update_and_draw_trails() {
 
 void draw_grid() {
     glLineWidth(1.0f); glBegin(GL_LINES); 
-    // THE MATRIX FLOOR (Cyan)
-    glColor3f(0.0f, 1.0f, 1.0f); 
+    if (local_state.scene_id == SCENE_GIZA_PLATEAU) glColor3f(0.55f, 0.48f, 0.22f);
+    else glColor3f(0.0f, 1.0f, 1.0f);
     for(int i=-4000; i<=4000; i+=50) { 
         glVertex3f(i, 0.1f, -4000); glVertex3f(i, 0.1f, 4000);
         glVertex3f(-4000, 0.1f, i); glVertex3f(4000, 0.1f, i); 
@@ -1169,6 +1246,17 @@ void draw_map() {
                 ng = 0.65f;
                 nb = 0.52f;
             }
+        } else if (local_state.scene_id == SCENE_GIZA_PLATEAU) {
+            nr = 0.72f + 0.12f * sinf(b.x * 0.003f + 0.2f);
+            ng = 0.58f + 0.10f * sinf((b.x + b.z) * 0.003f + 1.2f);
+            nb = 0.30f + 0.08f * sinf(b.z * 0.003f + 2.3f);
+            if (b.h > 24.0f && b.w > 120.0f && b.d > 120.0f) {
+                nr += 0.10f;
+                ng += 0.08f;
+            }
+            if (nr > 0.95f) nr = 0.95f;
+            if (ng > 0.82f) ng = 0.82f;
+            if (nb > 0.46f) nb = 0.46f;
         }
 
         glPushMatrix(); 
@@ -1637,6 +1725,8 @@ static void telecrystal_ring_color(const TelecrystalDef *def, int in_range, floa
         glColor3f(0.38f, 0.72f + pulse * 0.3f, 1.0f);
     } else if (def->target_scene_id == SCENE_DOCKS) {
         glColor3f(0.18f, 0.80f + pulse * 0.18f, 0.95f);
+    } else if (def->target_scene_id == SCENE_GIZA_PLATEAU) {
+        glColor3f(0.95f, 0.84f + pulse * 0.12f, 0.36f);
     } else if (def->target_scene_id == SCENE_CITY) {
         glColor3f(1.0f, 0.58f + pulse * 0.25f, 0.25f);
     } else {
@@ -1800,7 +1890,9 @@ void draw_scene(PlayerState *render_p) {
         town_render_world(&crisis_mock_state);
         draw_world_telecrystals(render_p);
     } else {
-        if (render_p->scene_id == SCENE_MINES || render_p->scene_id == SCENE_DOCKS) draw_world_telecrystals(render_p);
+        if (render_p->scene_id == SCENE_MINES || render_p->scene_id == SCENE_DOCKS || render_p->scene_id == SCENE_GIZA_PLATEAU) {
+            draw_world_telecrystals(render_p);
+        }
         draw_grid(); 
         update_and_draw_trails();
         draw_map();
@@ -1831,6 +1923,9 @@ void draw_scene(PlayerState *render_p) {
     } else if (render_p->scene_id == SCENE_DOCKS) {
         docks_draw_route_labels_2d(render_p);
         draw_string("DOCKS DISTRICT / FREIGHT QUAY", 42.0f, 92.0f, 4);
+    } else if (render_p->scene_id == SCENE_GIZA_PLATEAU) {
+        giza_draw_route_labels_2d(render_p);
+        draw_string("GIZA PLATEAU / PYRAMID NECROPOLIS", 42.0f, 92.0f, 4);
     } else if (render_p->scene_id == SCENE_WAREHOUSE) {
         draw_string("WAREHOUSE FLOOR / LOADING YARD", 42.0f, 92.0f, 4);
     }

--- a/packages/common/physics.h
+++ b/packages/common/physics.h
@@ -252,6 +252,104 @@ static const Box map_geo_docks[] = {
     {216.0f, 6.0f, 236.0f, 48.0f, 12.0f, 24.0f},
     {238.0f, 14.0f, 254.0f, 6.0f, 28.0f, 6.0f}
 };
+
+static const Box map_geo_giza[] = {
+    // FAR DESERT BASIN + framing ring
+    {0.0f, -4.0f, 0.0f, 4200.0f, 8.0f, 4200.0f},
+    {0.0f, 62.0f, -2100.0f, 4200.0f, 124.0f, 20.0f},
+    {0.0f, 62.0f, 2100.0f, 4200.0f, 124.0f, 20.0f},
+    {-2100.0f, 62.0f, 0.0f, 20.0f, 124.0f, 4200.0f},
+    {2100.0f, 62.0f, 0.0f, 20.0f, 124.0f, 4200.0f},
+
+    // SOUTH APRON / SPAWN FIELD (broad, flat, unobstructed)
+    {120.0f, 0.5f, -980.0f, 980.0f, 1.0f, 620.0f},
+    {120.0f, 1.3f, -735.0f, 820.0f, 2.6f, 160.0f},
+    {-320.0f, 1.0f, -900.0f, 240.0f, 2.0f, 320.0f},
+    {520.0f, 1.0f, -920.0f, 260.0f, 2.0f, 300.0f},
+    {280.0f, 1.8f, -1180.0f, 640.0f, 3.6f, 180.0f},
+
+    // Terrain language: low dunes, broad shelves, shallow bowls
+    {-720.0f, 5.0f, -620.0f, 460.0f, 10.0f, 220.0f},
+    {-380.0f, 4.0f, -520.0f, 520.0f, 8.0f, 240.0f},
+    {120.0f, 6.0f, -420.0f, 620.0f, 12.0f, 240.0f},
+    {760.0f, 7.0f, -560.0f, 520.0f, 14.0f, 260.0f},
+    {980.0f, 8.0f, -280.0f, 480.0f, 16.0f, 240.0f},
+    {-980.0f, 8.0f, -220.0f, 420.0f, 16.0f, 220.0f},
+    {-680.0f, 6.0f, 80.0f, 480.0f, 12.0f, 260.0f},
+    {540.0f, 8.0f, 40.0f, 640.0f, 16.0f, 280.0f},
+    {840.0f, 10.0f, 420.0f, 540.0f, 20.0f, 280.0f},
+    {-520.0f, 9.0f, 560.0f, 620.0f, 18.0f, 300.0f},
+    {160.0f, 7.0f, 760.0f, 900.0f, 14.0f, 260.0f},
+    {-940.0f, 8.0f, 860.0f, 420.0f, 16.0f, 240.0f},
+
+    // ESCARPMENT EDGE / altitude shelves
+    {-1460.0f, 18.0f, -140.0f, 360.0f, 36.0f, 1040.0f},
+    {1380.0f, 20.0f, 220.0f, 320.0f, 40.0f, 1160.0f},
+    {-120.0f, 24.0f, 1460.0f, 1320.0f, 48.0f, 280.0f},
+    {460.0f, 26.0f, -1520.0f, 1120.0f, 52.0f, 240.0f},
+    {-1120.0f, 30.0f, -1280.0f, 440.0f, 60.0f, 260.0f},
+    {1280.0f, 34.0f, 1320.0f, 460.0f, 68.0f, 260.0f},
+
+    // KHUFU MASS (dominant north-east)
+    {520.0f, 14.0f, 540.0f, 500.0f, 28.0f, 500.0f},
+    {520.0f, 28.0f, 540.0f, 430.0f, 28.0f, 430.0f},
+    {520.0f, 42.0f, 540.0f, 360.0f, 28.0f, 360.0f},
+    {520.0f, 56.0f, 540.0f, 292.0f, 28.0f, 292.0f},
+    {520.0f, 70.0f, 540.0f, 224.0f, 28.0f, 224.0f},
+    {520.0f, 84.0f, 540.0f, 156.0f, 28.0f, 156.0f},
+    {520.0f, 98.0f, 540.0f, 88.0f, 28.0f, 88.0f},
+    {520.0f, 4.0f, 540.0f, 760.0f, 8.0f, 760.0f},
+
+    // KHAFRE MASS (south-west of Khufu, on higher ground)
+    {120.0f, 20.0f, 140.0f, 450.0f, 40.0f, 450.0f},
+    {120.0f, 38.0f, 140.0f, 388.0f, 36.0f, 388.0f},
+    {120.0f, 54.0f, 140.0f, 322.0f, 32.0f, 322.0f},
+    {120.0f, 68.0f, 140.0f, 258.0f, 28.0f, 258.0f},
+    {120.0f, 80.0f, 140.0f, 196.0f, 24.0f, 196.0f},
+    {120.0f, 90.0f, 140.0f, 132.0f, 20.0f, 132.0f},
+    {120.0f, 7.0f, 140.0f, 700.0f, 14.0f, 700.0f},
+
+    // MENKAURE MASS (farther southwest and smaller)
+    {-420.0f, 13.0f, -400.0f, 300.0f, 26.0f, 300.0f},
+    {-420.0f, 25.0f, -400.0f, 246.0f, 24.0f, 246.0f},
+    {-420.0f, 35.0f, -400.0f, 194.0f, 20.0f, 194.0f},
+    {-420.0f, 43.0f, -400.0f, 144.0f, 16.0f, 144.0f},
+    {-420.0f, 49.0f, -400.0f, 94.0f, 12.0f, 94.0f},
+    {-420.0f, 4.0f, -400.0f, 520.0f, 8.0f, 520.0f},
+
+    // SPHINX / VALLEY BAND east-southeast of Khafre
+    {600.0f, 2.0f, -70.0f, 760.0f, 4.0f, 220.0f},
+    {700.0f, 6.0f, -92.0f, 170.0f, 12.0f, 38.0f},
+    {650.0f, 7.0f, -92.0f, 50.0f, 14.0f, 62.0f},
+    {742.0f, 8.0f, -96.0f, 44.0f, 16.0f, 44.0f},
+    {770.0f, 5.0f, -34.0f, 180.0f, 10.0f, 70.0f},
+    {834.0f, 6.0f, -58.0f, 88.0f, 12.0f, 44.0f},
+
+    // Causeway alignment from Khafre mass to valley band
+    {338.0f, 4.0f, 14.0f, 460.0f, 8.0f, 28.0f},
+    {500.0f, 3.0f, -6.0f, 360.0f, 6.0f, 20.0f},
+    {644.0f, 2.5f, -26.0f, 230.0f, 5.0f, 18.0f},
+    {350.0f, 1.2f, -34.0f, 520.0f, 2.4f, 24.0f},
+    {558.0f, 1.2f, -54.0f, 380.0f, 2.4f, 24.0f},
+
+    // Mastaba / ruin fields (sparse low rectilinear pads)
+    {300.0f, 2.0f, 260.0f, 80.0f, 4.0f, 36.0f},
+    {380.0f, 2.0f, 252.0f, 64.0f, 4.0f, 32.0f},
+    {448.0f, 2.0f, 250.0f, 60.0f, 4.0f, 30.0f},
+    {600.0f, 2.0f, 210.0f, 78.0f, 4.0f, 34.0f},
+    {668.0f, 2.0f, 190.0f, 64.0f, 4.0f, 30.0f},
+    {720.0f, 2.0f, 154.0f, 54.0f, 4.0f, 28.0f},
+    {48.0f, 2.0f, 300.0f, 70.0f, 4.0f, 34.0f},
+    {-20.0f, 2.0f, 340.0f, 68.0f, 4.0f, 32.0f},
+    {-98.0f, 2.0f, 280.0f, 66.0f, 4.0f, 30.0f},
+    {-140.0f, 2.0f, 206.0f, 56.0f, 4.0f, 28.0f},
+    {-240.0f, 2.0f, -132.0f, 70.0f, 4.0f, 36.0f},
+    {-316.0f, 2.0f, -90.0f, 62.0f, 4.0f, 30.0f},
+    {-350.0f, 2.0f, -178.0f, 58.0f, 4.0f, 30.0f},
+    {-486.0f, 2.0f, -184.0f, 56.0f, 4.0f, 28.0f},
+    {-520.0f, 2.0f, -312.0f, 64.0f, 4.0f, 32.0f},
+    {-320.0f, 2.0f, -470.0f, 72.0f, 4.0f, 34.0f}
+};
 #define CITY_MAX_BOXES 2048
 static Box map_geo_voxworld[CITY_MAX_BOXES];
 static int map_geo_voxworld_count = 0;
@@ -280,6 +378,9 @@ static int map_count = 0;
 #define DOCKS_KILL_Y -80.0f
 #define DOCKS_BOUNDS_X 260.0f
 #define DOCKS_BOUNDS_Z 300.0f
+#define GIZA_KILL_Y -120.0f
+#define GIZA_BOUNDS_X 2050.0f
+#define GIZA_BOUNDS_Z 2050.0f
 #define VOXWORLD_SEED 1337
 
 #define GARAGE_PORTAL_X 0.0f
@@ -379,6 +480,9 @@ static inline void phys_set_scene(int scene_id) {
     } else if (scene_id == SCENE_DOCKS) {
         map_geo = map_geo_docks;
         map_count = (int)(sizeof(map_geo_docks) / sizeof(Box));
+    } else if (scene_id == SCENE_GIZA_PLATEAU) {
+        map_geo = map_geo_giza;
+        map_count = (int)(sizeof(map_geo_giza) / sizeof(Box));
     } else {
         map_geo = map_geo_stadium;
         map_count = (int)(sizeof(map_geo_stadium) / sizeof(Box));
@@ -428,6 +532,14 @@ static inline void scene_spawn_point(int scene_id, int slot, float *out_x, float
         *out_x = offsets[idx];
         *out_y = 0.0f;
         *out_z = -168.0f;
+        return;
+    }
+    if (scene_id == SCENE_GIZA_PLATEAU) {
+        float offsets[] = {-80.0f, -30.0f, 20.0f, 70.0f, 120.0f};
+        int idx = slot % 5;
+        *out_x = offsets[idx];
+        *out_y = 0.0f;
+        *out_z = -980.0f;
         return;
     }
     if (slot % 2 == 0) {
@@ -502,6 +614,14 @@ static inline void scene_safety_check(PlayerState *p) {
         if (p->y < DOCKS_KILL_Y ||
             p->x < -DOCKS_BOUNDS_X || p->x > DOCKS_BOUNDS_X ||
             p->z < -DOCKS_BOUNDS_Z || p->z > DOCKS_BOUNDS_Z) {
+            scene_force_spawn(p);
+        }
+        return;
+    }
+    if (p->scene_id == SCENE_GIZA_PLATEAU) {
+        if (p->y < GIZA_KILL_Y ||
+            p->x < -GIZA_BOUNDS_X || p->x > GIZA_BOUNDS_X ||
+            p->z < -GIZA_BOUNDS_Z || p->z > GIZA_BOUNDS_Z) {
             scene_force_spawn(p);
         }
     }
@@ -803,7 +923,9 @@ void phys_respawn(PlayerState *p, unsigned int now) {
     p->active = 1; p->state = STATE_ALIVE;
     p->health = 100; p->shield = 100; p->respawn_time = 0; p->in_vehicle = 0;
     p->use_was_down = 0;
-    if (p->scene_id != SCENE_GARAGE_OSAKA && p->scene_id != SCENE_STADIUM && p->scene_id != SCENE_VOXWORLD && p->scene_id != SCENE_CITY && p->scene_id != SCENE_MINES && p->scene_id != SCENE_WAREHOUSE) {
+    if (p->scene_id != SCENE_GARAGE_OSAKA && p->scene_id != SCENE_STADIUM && p->scene_id != SCENE_VOXWORLD &&
+        p->scene_id != SCENE_CITY && p->scene_id != SCENE_MINES && p->scene_id != SCENE_WAREHOUSE &&
+        p->scene_id != SCENE_DOCKS && p->scene_id != SCENE_GIZA_PLATEAU) {
         p->scene_id = SCENE_GARAGE_OSAKA;
     }
     scene_spawn_point(p->scene_id, p->id, &p->x, &p->y, &p->z);

--- a/packages/common/protocol.h
+++ b/packages/common/protocol.h
@@ -13,6 +13,7 @@
 #define SCENE_MINES 4
 #define SCENE_WAREHOUSE 5
 #define SCENE_DOCKS 6
+#define SCENE_GIZA_PLATEAU 7
 #define SCENE_NEW_HANCLINGTON SCENE_CITY
 
 static inline const char *scene_id_name(int scene_id) {
@@ -24,6 +25,7 @@ static inline const char *scene_id_name(int scene_id) {
         case SCENE_MINES: return "SCENE_MINES";
         case SCENE_WAREHOUSE: return "WAREHOUSE";
         case SCENE_DOCKS: return "DOCKS";
+        case SCENE_GIZA_PLATEAU: return "GIZA_PLATEAU";
         default: return "SCENE_UNKNOWN";
     }
 }


### PR DESCRIPTION
### Motivation
- Provide a first-class, large-scale desert plateau scene designed for long sightlines, landmark navigation, and future helicopter gameplay integrated into the multi-scene world architecture. 
- Preserve the repo's box-based, traversal-first collision approach while keeping geometry simple and performant for immediate-mode rendering. 
- Expose the new scene to the lobby and world travel flow so players can load and teleport into/out of Giza Plateau like other world scenes. 

### Description
- Added a new scene id and name lookup: `SCENE_GIZA_PLATEAU` with `scene_id_name()` returning `"GIZA_PLATEAU"` in `packages/common/protocol.h`. 
- Implemented `map_geo_giza[]` in `packages/common/physics.h` composed of large Box primitives that form: far desert basin, south apron spawn field, Khufu/Khafre/Menkaure pyramid masses, Sphinx/valley band, causeway alignment, sparse mastaba/ruin fields, and escarpment framing; and wired it into `phys_set_scene()`. 
- Added scene lifecycle integration in `packages/common/physics.h`: spawn point for Giza in `scene_spawn_point()`, safety bounds and kill checks (`GIZA_KILL_Y`, `GIZA_BOUNDS_*`), and included Giza in `phys_respawn()` fallback logic. 
- Exposed the scene in the lobby and travel system (`apps/lobby/src/main.c`): added a `Giza Plateau` lobby option, resolved `"GIZA_PLATEAU"` in scene resolution, added bi-directional telecrystals (City ⇄ Giza), telecrystal coloring for Giza, and a small set of 2D metadata labels (`GREAT PYRAMID`, `KHAFRE`, `MENKAURE`, `SPHINX`, `SOUTH APRON`, `CAUSEWAY`) plus a scene banner. 
- Visual/readability tweaks in `apps/lobby/src/main.c` to prefer a sand/stone palette for grid and large-box color treatment when `SCENE_GIZA_PLATEAU` is active to improve silhouette readability from altitude. 

### Testing
- Built the game server with `make server` and the compile succeeded (server binary built). 
- Attempted to build the lobby with `make lobby` but the build failed in this environment due to missing system SDL2 headers/libraries; this is an environment limitation rather than a code error. 
- Verified through static inspection that `scene_load()` / `phys_set_scene()` now route to `map_geo_giza[]`, lobby selection resolves `GIZA_PLATEAU`, telecrystal defs include City↔Giza entries, and spawn/safety code references Giza bounds.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d426a8380883278cd6db286d83f427)