### PR TITLE
Add Detroit-inspired explorable cityscape (SCENE_CITY / SCENE_DETROIT_CORE)

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -128,7 +128,7 @@ static const TelecrystalDef TELECRYSTAL_DEFS[] = {
     {
         TELECRYSTAL_ID_TOWN_TO_MINES,
         SCENE_CITY,
-        270.0f, 0.0f, 60.0f,
+        -88.0f, 0.0f, 168.0f,
         14.0f,
         "G: TELEPORT MINES",
         SDL_SCANCODE_G,
@@ -152,8 +152,8 @@ static const TelecrystalDef TELECRYSTAL_DEFS[] = {
         500,
         1,
         SCENE_CITY,
-        270.0f, 0.0f, 60.0f,
-        180.0f,
+        -88.0f, 0.0f, 168.0f,
+        90.0f,
         0.0f,
         "TOWN"
     },
@@ -192,7 +192,7 @@ static const TelecrystalDef TELECRYSTAL_DEFS[] = {
     {
         TELECRYSTAL_ID_TOWN_TO_DOCKS,
         SCENE_CITY,
-        308.0f, 0.0f, 246.0f,
+        304.0f, 0.0f, 244.0f,
         14.0f,
         "G: TELEPORT DOCKS",
         SDL_SCANCODE_G,
@@ -216,7 +216,7 @@ static const TelecrystalDef TELECRYSTAL_DEFS[] = {
         500,
         1,
         SCENE_CITY,
-        300.0f, 0.0f, 238.0f,
+        304.0f, 0.0f, 244.0f,
         210.0f,
         0.0f,
         "TOWN"
@@ -224,7 +224,7 @@ static const TelecrystalDef TELECRYSTAL_DEFS[] = {
     {
         TELECRYSTAL_ID_TOWN_TO_GIZA,
         SCENE_CITY,
-        98.0f, 0.0f, 318.0f,
+        430.0f, 0.0f, 42.0f,
         16.0f,
         "G: TELEPORT GIZA PLATEAU",
         SDL_SCANCODE_G,
@@ -248,8 +248,8 @@ static const TelecrystalDef TELECRYSTAL_DEFS[] = {
         500,
         1,
         SCENE_CITY,
-        98.0f, 0.0f, 318.0f,
-        188.0f,
+        430.0f, 0.0f, 42.0f,
+        220.0f,
         0.0f,
         "TOWN"
     }
@@ -732,7 +732,7 @@ typedef struct {
 static const LobbySceneOption LOBBY_SCENE_OPTIONS[] = {
     {"Garage", "GARAGE_OSAKA", SCENE_GARAGE_OSAKA},
     {"Stadium", "STADIUM", SCENE_STADIUM},
-    {"New Hanclington", "NEW_HANCLINGTON_MOCKUP", SCENE_NEW_HANCLINGTON},
+    {"Detroit Core", "DETROIT_CORE", SCENE_NEW_HANCLINGTON},
     {"Warehouse", "WAREHOUSE", SCENE_WAREHOUSE},
     {"Mines", "MINES", SCENE_MINES},
     {"Docks", "DOCKS", SCENE_DOCKS},
@@ -816,6 +816,8 @@ static int lobby_resolve_scene_id(const char *scene_id) {
     if (strcmp(scene_id, "STADIUM") == 0) return SCENE_STADIUM;
     if (strcmp(scene_id, "NEW_HANCLINGTON_MOCKUP") == 0) return SCENE_NEW_HANCLINGTON;
     if (strcmp(scene_id, "NEW_HANCLINGTON") == 0) return SCENE_NEW_HANCLINGTON;
+    if (strcmp(scene_id, "DETROIT_CORE") == 0) return SCENE_NEW_HANCLINGTON;
+    if (strcmp(scene_id, "SCENE_DETROIT_CORE") == 0) return SCENE_NEW_HANCLINGTON;
     if (strcmp(scene_id, "SCENE_CITY") == 0) return SCENE_NEW_HANCLINGTON;
     if (strcmp(scene_id, "WAREHOUSE") == 0) return SCENE_WAREHOUSE;
     if (strcmp(scene_id, "SCENE_WAREHOUSE") == 0) return SCENE_WAREHOUSE;

--- a/packages/common/physics.h
+++ b/packages/common/physics.h
@@ -95,11 +95,98 @@ static const Box map_geo_garage[] = {
 
 
 static const Box map_geo_city[] = {
-    {150.0f, -6.0f, 150.0f, 420.0f, 12.0f, 420.0f},
-    {150.0f, 24.0f, -60.0f, 420.0f, 60.0f, 12.0f},
-    {150.0f, 24.0f, 360.0f, 420.0f, 60.0f, 12.0f},
-    {-60.0f, 24.0f, 150.0f, 12.0f, 60.0f, 420.0f},
-    {360.0f, 24.0f, 150.0f, 12.0f, 60.0f, 420.0f}
+    // District floorplate + retaining shell
+    {180.0f, -6.0f, 180.0f, 880.0f, 12.0f, 880.0f},
+    {180.0f, 30.0f, -260.0f, 880.0f, 60.0f, 12.0f},
+    {180.0f, 30.0f, 620.0f, 880.0f, 60.0f, 12.0f},
+    {-260.0f, 30.0f, 180.0f, 12.0f, 60.0f, 880.0f},
+    {620.0f, 30.0f, 180.0f, 12.0f, 60.0f, 880.0f},
+
+    // Grand Avenue spine (north-south boulevard edges)
+    {180.0f, 4.0f, 180.0f, 32.0f, 8.0f, 760.0f},
+    {122.0f, 6.0f, 180.0f, 6.0f, 12.0f, 760.0f},
+    {238.0f, 6.0f, 180.0f, 6.0f, 12.0f, 760.0f},
+
+    // Civic core / campus plaza podium + monument
+    {180.0f, 1.8f, 176.0f, 132.0f, 3.6f, 120.0f},
+    {180.0f, 0.5f, 176.0f, 46.0f, 1.0f, 46.0f},
+    {180.0f, 9.0f, 176.0f, 10.0f, 18.0f, 10.0f},
+    {180.0f, 14.0f, 176.0f, 18.0f, 4.0f, 18.0f},
+    {132.0f, 8.0f, 132.0f, 40.0f, 16.0f, 40.0f},
+    {228.0f, 8.0f, 132.0f, 40.0f, 16.0f, 40.0f},
+    {132.0f, 8.0f, 220.0f, 40.0f, 16.0f, 40.0f},
+    {228.0f, 8.0f, 220.0f, 40.0f, 16.0f, 40.0f},
+
+    // Financial / riverward edge towers + canyon
+    {320.0f, 38.0f, -22.0f, 70.0f, 76.0f, 56.0f},
+    {414.0f, 44.0f, 12.0f, 64.0f, 88.0f, 64.0f},
+    {344.0f, 16.0f, 54.0f, 112.0f, 32.0f, 54.0f},
+    {430.0f, 22.0f, 98.0f, 90.0f, 44.0f, 58.0f},
+    {300.0f, 18.0f, 116.0f, 78.0f, 36.0f, 62.0f},
+
+    // Stadium / entertainment district (north + northeast)
+    {248.0f, 10.0f, 390.0f, 220.0f, 20.0f, 170.0f},
+    {248.0f, 22.0f, 390.0f, 170.0f, 24.0f, 120.0f},
+    {248.0f, 32.0f, 390.0f, 124.0f, 20.0f, 78.0f},
+    {98.0f, 7.0f, 352.0f, 86.0f, 14.0f, 66.0f},
+    {88.0f, 4.0f, 438.0f, 140.0f, 8.0f, 70.0f},
+
+    // Brush blocks / neighborhood grid (northwest + north)
+    {2.0f, 8.0f, 294.0f, 50.0f, 16.0f, 44.0f},
+    {62.0f, 7.0f, 286.0f, 46.0f, 14.0f, 38.0f},
+    {14.0f, 6.0f, 354.0f, 56.0f, 12.0f, 44.0f},
+    {74.0f, 9.0f, 362.0f, 48.0f, 18.0f, 46.0f},
+    {2.0f, 7.0f, 422.0f, 52.0f, 14.0f, 40.0f},
+    {64.0f, 8.0f, 430.0f, 52.0f, 16.0f, 42.0f},
+    {24.0f, 12.0f, 500.0f, 74.0f, 24.0f, 54.0f},
+
+    // Warehouse / utility edge (west + southwest)
+    {-118.0f, 12.0f, 156.0f, 118.0f, 24.0f, 74.0f},
+    {-118.0f, 24.0f, 156.0f, 88.0f, 4.0f, 54.0f},
+    {-130.0f, 8.0f, 72.0f, 96.0f, 16.0f, 54.0f},
+    {-122.0f, 8.0f, 242.0f, 102.0f, 16.0f, 62.0f},
+    {-54.0f, 5.0f, 234.0f, 48.0f, 10.0f, 38.0f},
+
+    // Primary parking deck landmark (multi-level, enterable)
+    {292.0f, 2.0f, 276.0f, 84.0f, 4.0f, 84.0f},
+    {292.0f, 8.0f, 276.0f, 84.0f, 4.0f, 84.0f},
+    {292.0f, 14.0f, 276.0f, 84.0f, 4.0f, 84.0f},
+    {332.0f, 11.0f, 276.0f, 4.0f, 22.0f, 84.0f},
+    {252.0f, 11.0f, 276.0f, 4.0f, 22.0f, 84.0f},
+    {292.0f, 11.0f, 332.0f, 84.0f, 22.0f, 4.0f},
+    {292.0f, 11.0f, 236.0f, 84.0f, 22.0f, 4.0f},
+    {304.0f, 6.0f, 236.0f, 20.0f, 2.0f, 20.0f},
+    {316.0f, 10.0f, 248.0f, 20.0f, 2.0f, 20.0f},
+    {328.0f, 14.0f, 260.0f, 20.0f, 2.0f, 20.0f},
+
+    // Rooftop route links + maintenance catwalks
+    {184.0f, 18.0f, 302.0f, 120.0f, 2.0f, 8.0f},
+    {236.0f, 20.0f, 250.0f, 8.0f, 2.0f, 108.0f},
+    {124.0f, 16.0f, 258.0f, 8.0f, 2.0f, 76.0f},
+    {88.0f, 14.0f, 288.0f, 64.0f, 2.0f, 8.0f},
+    {40.0f, 14.0f, 324.0f, 8.0f, 2.0f, 72.0f},
+
+    // Transit guideway (elevated people-mover vibe)
+    {206.0f, 24.0f, 176.0f, 12.0f, 4.0f, 620.0f},
+    {206.0f, 28.0f, 176.0f, 24.0f, 2.0f, 620.0f},
+    {206.0f, 16.0f, -98.0f, 6.0f, 32.0f, 6.0f},
+    {206.0f, 16.0f, 82.0f, 6.0f, 32.0f, 6.0f},
+    {206.0f, 16.0f, 262.0f, 6.0f, 32.0f, 6.0f},
+    {206.0f, 16.0f, 442.0f, 6.0f, 32.0f, 6.0f},
+
+    // Highway scars / edge barriers + ramps
+    {420.0f, 14.0f, 360.0f, 170.0f, 28.0f, 18.0f},
+    {482.0f, 18.0f, 258.0f, 18.0f, 36.0f, 202.0f},
+    {396.0f, 12.0f, 470.0f, 126.0f, 24.0f, 18.0f},
+    {452.0f, 10.0f, 420.0f, 70.0f, 20.0f, 16.0f},
+    {470.0f, 6.0f, 448.0f, 34.0f, 12.0f, 14.0f},
+
+    // Alley/service blockers for navigation rhythm
+    {60.0f, 3.0f, 180.0f, 6.0f, 6.0f, 240.0f},
+    {-18.0f, 3.0f, 250.0f, 84.0f, 6.0f, 6.0f},
+    {42.0f, 3.0f, 102.0f, 90.0f, 6.0f, 6.0f},
+    {108.0f, 3.0f, 88.0f, 6.0f, 6.0f, 86.0f},
+    {352.0f, 3.0f, 188.0f, 6.0f, 6.0f, 130.0f}
 };
 
 static const Box map_geo_mines[] = {
@@ -507,9 +594,17 @@ static inline void scene_spawn_point(int scene_id, int slot, float *out_x, float
         return;
     }
     if (scene_id == SCENE_CITY) {
-        *out_x = 150.0f;
-        *out_y = 15.0f;
-        *out_z = 174.0f;
+        static const float city_spawns[][3] = {
+            {180.0f, 8.0f, 176.0f},  // Campus Plaza
+            {36.0f, 8.0f, 338.0f},   // Brush Blocks edge
+            {244.0f, 10.0f, 470.0f}, // Stadium approach
+            {-86.0f, 8.0f, 158.0f},  // Warehouse edge
+            {332.0f, 8.0f, 74.0f}    // Financial edge
+        };
+        int idx = slot % 5;
+        *out_x = city_spawns[idx][0];
+        *out_y = city_spawns[idx][1];
+        *out_z = city_spawns[idx][2];
         return;
     }
     if (scene_id == SCENE_MINES) {
@@ -589,7 +684,7 @@ static inline void scene_safety_check(PlayerState *p) {
         }
     }
     if (p->scene_id == SCENE_CITY) {
-        if (p->y < -90.0f || p->x < -90.0f || p->x > 390.0f || p->z < -90.0f || p->z > 390.0f) {
+        if (p->y < -90.0f || p->x < -280.0f || p->x > 640.0f || p->z < -280.0f || p->z > 640.0f) {
             scene_force_spawn(p);
         }
         return;

--- a/packages/common/protocol.h
+++ b/packages/common/protocol.h
@@ -16,13 +16,14 @@
 #define SCENE_DOCKS 6
 #define SCENE_GIZA_PLATEAU 7
 #define SCENE_NEW_HANCLINGTON SCENE_CITY
+#define SCENE_DETROIT_CORE SCENE_CITY
 
 static inline const char *scene_id_name(int scene_id) {
     switch (scene_id) {
         case SCENE_GARAGE_OSAKA: return "SCENE_GARAGE_OSAKA";
         case SCENE_STADIUM: return "SCENE_STADIUM";
         case SCENE_VOXWORLD: return "SCENE_VOXWORLD";
-        case SCENE_CITY: return "SCENE_NEW_HANCLINGTON";
+        case SCENE_CITY: return "SCENE_DETROIT_CORE";
         case SCENE_MINES: return "SCENE_MINES";
         case SCENE_WAREHOUSE: return "WAREHOUSE";
         case SCENE_DOCKS: return "DOCKS";

--- a/packages/world/town_map.c
+++ b/packages/world/town_map.c
@@ -3,41 +3,42 @@
 #define TOWN_WORLD_SCALE 3.0f
 
 static const TownBuilding g_buildings[] = {
-    {BLD_AUCTION_HOUSE, "Auction House", 50, 52, 34, 8, 8, 0},
-    {BLD_TOWN_HALL, "Town Hall", 66, 61, 10, 8, 10, 0},
-    {BLD_GUILD_HOUSE, "Guild House", 36, 58, 10, 8, 8, 0},
-    {BLD_GOLD_GUILD, "Gold Guild", 28, 56, 10, 8, 8, 0},
-    {BLD_POST_OFFICE, "Post Office", 22, 44, 12, 8, 7, 0},
-    {BLD_BLACKSMITH, "Blacksmith", 28, 68, 8, 8, 8, 0},
-    {BLD_WEAPONS_GUILD, "Weapons Guild", 33, 82, 14, 10, 8, 0},
-    {BLD_POTIONS, "Potions", 58, 66, 8, 8, 7, 0},
-    {BLD_ALCHEMY_SHOP, "Alchemy Shop", 72, 66, 10, 8, 7, 0},
-    {BLD_SHADY_DEALER, "Shady Dealer", 82, 60, 10, 8, 8, 0},
-    {BLD_FISH_SHOP, "Fish Shop", 52, 86, 10, 8, 7, 0},
-    {BLD_ARMOR_SHOP, "Armor Shop", 72, 74, 10, 8, 8, 0},
-    {BLD_MINECO_OPS, "Mineco Ops", 45, 26, 12, 8, 8, 0},
-    {BLD_MINING_SUPPLIES, "Mining Supplies", 60, 26, 12, 8, 8, 0},
-    {BLD_ARCHERY_GUILD, "Archery Guild", 84, 40, 12, 10, 8, 0},
-    {BLD_POLICE, "Police", 66, 34, 8, 6, 7, 0},
-    {BLD_GLOVE_SHOP, "Glove Shop", 80, 22, 8, 8, 7, 0},
+    {BLD_AUCTION_HOUSE, "Campus Tower", 60, 52, 20, 16, 24, 0},
+    {BLD_TOWN_HALL, "Civic Hall", 60, 60, 12, 10, 16, 0},
+    {BLD_GUILD_HOUSE, "Grand Ave South Lobby", 46, 46, 18, 12, 12, 0},
+    {BLD_GOLD_GUILD, "Grand Ave North Lobby", 62, 82, 16, 12, 12, 0},
+    {BLD_POST_OFFICE, "Brush Row North", 14, 96, 16, 14, 10, 0},
+    {BLD_BLACKSMITH, "Brush Row Court", 24, 112, 16, 12, 10, 0},
+    {BLD_WEAPONS_GUILD, "Brush Hall", 16, 136, 24, 16, 14, 0},
+    {BLD_POTIONS, "Stadium Concourse", 82, 132, 26, 18, 16, 0},
+    {BLD_ALCHEMY_SHOP, "Event Plaza Hall", 96, 124, 18, 14, 12, 0},
+    {BLD_SHADY_DEALER, "Arena Garage", 98, 92, 24, 24, 16, 0},
+    {BLD_FISH_SHOP, "Warehouse Bay A", 8, 54, 28, 16, 12, 0},
+    {BLD_ARMOR_SHOP, "Warehouse Bay B", 8, 74, 26, 16, 12, 0},
+    {BLD_MINECO_OPS, "Utility Annex", 22, 78, 14, 10, 8, 0},
+    {BLD_MINING_SUPPLIES, "Utility Garage", 22, 50, 14, 10, 8, 0},
+    {BLD_ARCHERY_GUILD, "Financial Podium", 118, 42, 22, 16, 18, 0},
+    {BLD_POLICE, "Riverward Core", 134, 34, 20, 18, 20, 0},
+    {BLD_GLOVE_SHOP, "Congress Exchange", 110, 22, 18, 14, 14, 0},
 };
 
 static const CrisisSocket g_sockets[] = {
-    {SOCK_ANCHOR_AUCTION, "Anchor: Auction", 52, 58, 3.5f, SOCK_ROLE_BUILDER, 1},
-    {SOCK_RITUAL_TOWN_HALL, "Ritual: Town Hall", 66, 61, 3.5f, SOCK_ROLE_RITUALIST, 1},
-    {SOCK_INTERCEPT_DOCK_ROUTE, "Intercept: Docks", 84, 86, 4.0f, SOCK_ROLE_STRIKE | SOCK_ROLE_SCOUT, 1},
-    {SOCK_INTERCEPT_MINES_ROUTE, "Intercept: Mines", 88, 20, 4.0f, SOCK_ROLE_STRIKE | SOCK_ROLE_SCOUT, 1},
-    {SOCK_HEAD_A_DOCKS, "Head A: Docks Edge", 90, 82, 4.5f, SOCK_ROLE_STRIKE, 0},
-    {SOCK_HEAD_B_MINES, "Head B: Mines Edge", 92, 18, 4.5f, SOCK_ROLE_STRIKE, 0},
-    {SOCK_SECRET_GATE_PRESSURE, "Secret Gate Pressure", 12, 20, 3.0f, SOCK_ROLE_SCOUT, 1}
+    {SOCK_ANCHOR_AUCTION, "Anchor: CAMPUS PLAZA", 60, 58, 3.5f, SOCK_ROLE_BUILDER, 1},
+    {SOCK_RITUAL_TOWN_HALL, "Anchor: GRAND AVENUE", 60, 86, 3.5f, SOCK_ROLE_RITUALIST, 1},
+    {SOCK_INTERCEPT_DOCK_ROUTE, "Anchor: STADIUM DISTRICT", 96, 132, 4.0f, SOCK_ROLE_STRIKE | SOCK_ROLE_SCOUT, 1},
+    {SOCK_INTERCEPT_MINES_ROUTE, "Anchor: FINANCIAL EDGE", 120, 24, 4.0f, SOCK_ROLE_STRIKE | SOCK_ROLE_SCOUT, 1},
+    {SOCK_HEAD_A_DOCKS, "Anchor: WAREHOUSE EDGE", 8, 62, 4.5f, SOCK_ROLE_STRIKE, 0},
+    {SOCK_HEAD_B_MINES, "Anchor: BRUSH BLOCKS", 16, 112, 4.5f, SOCK_ROLE_STRIKE, 0},
+    {SOCK_SECRET_GATE_PRESSURE, "Anchor: RIVER GATE", 142, 18, 3.0f, SOCK_ROLE_SCOUT, 1}
 };
 
 static const TownRoutePoint g_routes[] = {
-    {"Auction", 50, 52},
-    {"Docks", 90, 86},
-    {"Mines", 90, 20},
-    {"Secret Gate", 12, 20},
-    {"Town Hall", 66, 61}
+    {"Campus Plaza", 60, 58},
+    {"Grand Avenue", 60, 86},
+    {"Stadium District", 96, 132},
+    {"Brush Blocks", 20, 114},
+    {"Warehouse Edge", 8, 62},
+    {"Financial Edge", 120, 24}
 };
 
 static TownBuilding g_buildings_scaled[sizeof(g_buildings) / sizeof(g_buildings[0])];

--- a/packages/world/town_render.c
+++ b/packages/world/town_render.c
@@ -75,11 +75,11 @@ static void draw_ring(float x, float z, float y, float radius, float r, float g,
 }
 
 static void draw_mock_door(const TownBuilding *b) {
-    float dx = (b->x >= 150.0f) ? 1.0f : -1.0f;
+    float dx = (b->x >= 180.0f) ? 1.0f : -1.0f;
     float dz = 0.0f;
-    if (fabsf(b->x - 150.0f) < 50.0f) {
+    if (fabsf(b->x - 180.0f) < 50.0f) {
         dx = 0.0f;
-        dz = (b->z >= 150.0f) ? -1.0f : 1.0f;
+        dz = (b->z >= 180.0f) ? -1.0f : 1.0f;
     }
 
     float half_w = b->w * 0.5f;
@@ -153,12 +153,12 @@ int town_render_collect_labels(const CrisisMockState *state,
     }
 
     const float gates[][2] = {
-        {270.0f, 258.0f}, // docks
-        {36.0f, 60.0f},   // secret gate
-        {270.0f, 54.0f},  // mines
-        {24.0f, 174.0f}   // residences / west edge
+        {304.0f, 244.0f},
+        {-58.0f, 168.0f},
+        {462.0f, 356.0f},
+        {34.0f, 462.0f}
     };
-    const char *gate_names[] = {"Gate Docks", "Gate Secret", "Gate Mines", "Gate Residences"};
+    const char *gate_names[] = {"Gate Garage", "Gate Warehouse", "Gate Freeway", "Gate Brush"};
     for (int i = 0; i < 4 && out_count < max_labels; i++) {
         TownMetaLabel *lbl = &out_labels[out_count++];
         snprintf(lbl->text, sizeof(lbl->text), "%s", gate_names[i]);
@@ -167,6 +167,28 @@ int town_render_collect_labels(const CrisisMockState *state,
         float near_roof = town_label_roof_height(lbl->x, lbl->z);
         lbl->y = clampf(near_roof + town_label_gate_clearance, 2.0f, town_label_height_max - 4.0f);
         lbl->mode = TOWN_LABEL_GATE;
+    }
+
+    const struct {
+        const char *text;
+        float x, y, z;
+        TownLabelMode mode;
+    } district_labels[] = {
+        {"CAMPUS PLAZA", 180.0f, 22.0f, 176.0f, TOWN_LABEL_LANDMARK},
+        {"GRAND AVENUE", 180.0f, 20.0f, 320.0f, TOWN_LABEL_ROUTE},
+        {"STADIUM DISTRICT", 248.0f, 30.0f, 420.0f, TOWN_LABEL_LANDMARK},
+        {"BRUSH BLOCKS", 38.0f, 24.0f, 420.0f, TOWN_LABEL_ROUTE},
+        {"WAREHOUSE EDGE", -104.0f, 20.0f, 168.0f, TOWN_LABEL_ROUTE},
+        {"FINANCIAL EDGE", 360.0f, 30.0f, 48.0f, TOWN_LABEL_LANDMARK},
+        {"CIVIC CORE", 180.0f, 18.0f, 124.0f, TOWN_LABEL_GATE}
+    };
+    for (size_t i = 0; i < sizeof(district_labels) / sizeof(district_labels[0]) && out_count < max_labels; i++) {
+        TownMetaLabel *lbl = &out_labels[out_count++];
+        snprintf(lbl->text, sizeof(lbl->text), "%s", district_labels[i].text);
+        lbl->x = district_labels[i].x;
+        lbl->y = district_labels[i].y;
+        lbl->z = district_labels[i].z;
+        lbl->mode = district_labels[i].mode;
     }
 
     for (int i = 0; i < out_count; i++) {
@@ -192,15 +214,18 @@ void town_render_world(const CrisisMockState *state) {
         printf("[TOWN] outline pass=on\n");
     }
 
-    draw_box(150.0f, -4.5f, 150.0f, 360.0f, 9.0f, 360.0f, 0.04f, 0.04f, 0.05f);
-    draw_box(150.0f, 6.0f, 150.0f, 300.0f, 12.0f, 6.0f, 0.12f, 0.12f, 0.14f);
-    draw_box(150.0f, 6.0f, 150.0f, 6.0f, 12.0f, 300.0f, 0.12f, 0.12f, 0.14f);
-    draw_box(150.0f, 6.0f, 300.0f, 300.0f, 12.0f, 6.0f, 0.20f, 0.20f, 0.22f);
-    draw_box(150.0f, 6.0f, 0.0f, 300.0f, 12.0f, 6.0f, 0.20f, 0.20f, 0.22f);
+    draw_box(180.0f, -4.5f, 180.0f, 860.0f, 9.0f, 860.0f, 0.03f, 0.03f, 0.04f);
+    draw_box(180.0f, 6.0f, 180.0f, 120.0f, 12.0f, 760.0f, 0.11f, 0.12f, 0.14f); // grand avenue
+    draw_box(180.0f, 1.2f, 176.0f, 132.0f, 2.4f, 120.0f, 0.16f, 0.16f, 0.18f); // civic plaza
+    draw_box(248.0f, 2.0f, 390.0f, 248.0f, 4.0f, 196.0f, 0.14f, 0.14f, 0.15f); // stadium/event apron
+    draw_box(300.0f, 4.0f, 68.0f, 196.0f, 8.0f, 150.0f, 0.10f, 0.11f, 0.14f);  // financial podium
+    draw_box(-96.0f, 2.0f, 168.0f, 164.0f, 4.0f, 198.0f, 0.11f, 0.10f, 0.10f);  // warehouse apron
 
-    draw_box_outline(150.0f, -4.5f, 150.0f, 360.0f, 9.0f, 360.0f, 0.18f, 0.90f, 0.92f, 1.5f);
-    draw_box_outline(150.0f, 6.0f, 150.0f, 300.0f, 12.0f, 6.0f, 0.98f, 0.78f, 0.25f, 1.4f);
-    draw_box_outline(150.0f, 6.0f, 150.0f, 6.0f, 12.0f, 300.0f, 0.98f, 0.78f, 0.25f, 1.4f);
+    draw_box_outline(180.0f, -4.5f, 180.0f, 860.0f, 9.0f, 860.0f, 0.18f, 0.90f, 0.92f, 1.4f);
+    draw_box_outline(180.0f, 6.0f, 180.0f, 120.0f, 12.0f, 760.0f, 0.98f, 0.78f, 0.25f, 1.4f);
+    draw_box_outline(180.0f, 1.2f, 176.0f, 132.0f, 2.4f, 120.0f, 0.30f, 0.94f, 0.94f, 1.8f);
+    draw_box_outline(248.0f, 2.0f, 390.0f, 248.0f, 4.0f, 196.0f, 0.95f, 0.55f, 0.20f, 1.6f);
+    draw_box_outline(-96.0f, 2.0f, 168.0f, 164.0f, 4.0f, 198.0f, 0.35f, 0.88f, 0.95f, 1.6f);
 
     size_t bcount = 0;
     const TownBuilding *b = town_map_buildings(&bcount);
@@ -208,8 +233,8 @@ void town_render_world(const CrisisMockState *state) {
     for (size_t i = 0; i < bcount; i++) {
         float base = (b[i].id == BLD_AUCTION_HOUSE) ? 0.09f : 0.06f;
         float j = (hash01((unsigned int)b[i].id + 17U) - 0.5f) * 0.045f;
-        float district_x = (b[i].x < 150.0f) ? 0.012f : -0.006f;
-        float district_z = (b[i].z > 150.0f) ? 0.010f : -0.004f;
+        float district_x = (b[i].x < 180.0f) ? 0.012f : -0.006f;
+        float district_z = (b[i].z > 180.0f) ? 0.010f : -0.004f;
         float r = clampf(base + j + district_x, 0.04f, 0.17f);
         float g = clampf(base + j * 0.7f + district_z, 0.04f, 0.17f);
         float bl = clampf(base + 0.02f + j * 0.6f + district_x * 0.5f, 0.05f, 0.20f);
@@ -224,7 +249,11 @@ void town_render_world(const CrisisMockState *state) {
         door_count++;
     }
 
-    draw_box_outline(150.0f, 12.0f, 156.0f, 108.0f, 2.0f, 7.0f, 1.0f, 0.95f, 0.35f, 2.1f);
+    // District landmarks
+    draw_box_outline(180.0f, 9.0f, 176.0f, 10.0f, 18.0f, 10.0f, 1.0f, 0.95f, 0.35f, 2.2f);   // monument
+    draw_box_outline(248.0f, 22.0f, 390.0f, 170.0f, 24.0f, 120.0f, 1.0f, 0.55f, 0.2f, 2.1f); // stadium bowl
+    draw_box_outline(292.0f, 14.0f, 276.0f, 84.0f, 28.0f, 84.0f, 0.95f, 0.92f, 0.35f, 1.8f); // garage landmark
+    draw_box_outline(414.0f, 44.0f, 12.0f, 64.0f, 88.0f, 64.0f, 0.88f, 0.95f, 1.0f, 1.6f);   // financial tower
 
     size_t scount = 0;
     const CrisisSocket *s = town_map_sockets(&scount);
@@ -241,10 +270,10 @@ void town_render_world(const CrisisMockState *state) {
         }
     }
 
-    draw_mock_gate(270.0f, 258.0f, 20.0f, 18.0f, 0.95f, 0.72f, 0.25f); // Docks route
-    draw_mock_gate(36.0f, 60.0f, 16.0f, 16.0f, 0.25f, 0.95f, 0.95f);   // Secret gate
-    draw_mock_gate(270.0f, 54.0f, 18.0f, 18.0f, 0.98f, 0.55f, 0.20f);   // Mines exit
-    draw_mock_gate(24.0f, 174.0f, 16.0f, 16.0f, 0.35f, 0.88f, 0.95f);   // Residences route
+    draw_mock_gate(304.0f, 244.0f, 24.0f, 18.0f, 0.95f, 0.72f, 0.25f); // garage / stadium seam
+    draw_mock_gate(-58.0f, 168.0f, 16.0f, 16.0f, 0.25f, 0.95f, 0.95f); // warehouse edge gate
+    draw_mock_gate(462.0f, 356.0f, 18.0f, 18.0f, 0.98f, 0.55f, 0.20f); // freeway barrier break
+    draw_mock_gate(34.0f, 462.0f, 16.0f, 16.0f, 0.35f, 0.88f, 0.95f);  // brush blocks gate
 
     if (log_once == 1) {
         log_once = 2;


### PR DESCRIPTION
### Motivation
- Provide a larger, exploration-first downtown scene with readable districts, landmarks, verticality, and entry points so the world can host traversal, rooftops, plazas, garages and future gameplay modes rather than the current tiny arena-like city slice. 
- Align the implementation with the repo's multi-scene patterns (scene resolver, telecrystals, spawn/safety, and projected labels) so the new blockout composes cleanly with existing scenes and travel hooks.

### Description
- Replaced the small city collision/blockout with a district-scale layout in `packages/common/physics.h` that includes a civic/campus plaza, a north–south Grand Avenue spine, stadium/event district, brush-style neighborhood blocks, warehouse/utility edge, financial/riverward edge, rooftop links, elevated transit guideway, parking-deck volumes, and highway seam barriers. 
- Added distributed city spawn anchors and expanded safety bounds in `packages/common/physics.h` so players spawn at meaningful district entry points and do not immediately leave the larger footprint. 
- Updated town metadata and map primitives in `packages/world/town_map.c` to rename and reposition building landmarks, sockets and route points to match the new Detroit-core districts. 
- Updated visual blockout, landmark outlines, gates and added sparse projected district labels in `packages/world/town_render.c` to make major anchors readable (`CAMPUS PLAZA`, `GRAND AVENUE`, `STADIUM DISTRICT`, `BRUSH BLOCKS`, `WAREHOUSE EDGE`, `FINANCIAL EDGE`, `CIVIC CORE`). 
- Moved telecrystal placements and travel anchors in `apps/lobby/src/main.c` to district seams and adjusted telecrystal destinations; added lobby UI entries and resolver aliases for the new scene name. 
- Introduced `SCENE_DETROIT_CORE` alias and updated scene display name in `packages/common/protocol.h`, and changed the lobby scene picker label to `Detroit Core` while keeping `SCENE_CITY` as the canonical id for compatibility. 
- Files changed: `packages/common/physics.h`, `packages/world/town_map.c`, `packages/world/town_render.c`, `packages/common/protocol.h`, and `apps/lobby/src/main.c`.

### Testing
- Automated build attempt with `make lobby` was executed and failed in this environment due to missing SDL2 development headers (`SDL2/SDL.h`, `SDL2/SDL_opengl.h`), so an in-container compile could not be completed. 
- Source-level sanity checks were performed (file compile attempts and basic runtime wiring inspection), and the scene integration points (scene resolver, `phys_set_scene`, telecrystal defs, spawn/safety checks and lobby options) were updated consistently across files with no syntactic errors reported by the local tooling used here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d44a048030832797f79af9385e441a)