### PR TITLE
Restore Town (SCENE_CITY) authority and remove Detroit Core routing

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -315,8 +315,8 @@ static void telecrystal_reset_runtime(void);
 #define NET_JITTER_DIAG 0
 #endif
 
-#ifndef DEBUG_BOOT_NEW_HANCLINGTON
-#define DEBUG_BOOT_NEW_HANCLINGTON 0
+#ifndef DEBUG_BOOT_TOWN
+#define DEBUG_BOOT_TOWN 0
 #endif
 
 #ifndef TELECRYSTAL_DEBUG
@@ -732,7 +732,7 @@ typedef struct {
 static const LobbySceneOption LOBBY_SCENE_OPTIONS[] = {
     {"Garage", "GARAGE_OSAKA", SCENE_GARAGE_OSAKA},
     {"Stadium", "STADIUM", SCENE_STADIUM},
-    {"Detroit Core", "DETROIT_CORE", SCENE_NEW_HANCLINGTON},
+    {"Town", "TOWN", SCENE_CITY},
     {"Warehouse", "WAREHOUSE", SCENE_WAREHOUSE},
     {"Mines", "MINES", SCENE_MINES},
     {"Docks", "DOCKS", SCENE_DOCKS},
@@ -814,11 +814,8 @@ static int lobby_resolve_scene_id(const char *scene_id) {
     if (!scene_id || !scene_id[0]) return -1;
     if (strcmp(scene_id, "GARAGE_OSAKA") == 0) return SCENE_GARAGE_OSAKA;
     if (strcmp(scene_id, "STADIUM") == 0) return SCENE_STADIUM;
-    if (strcmp(scene_id, "NEW_HANCLINGTON_MOCKUP") == 0) return SCENE_NEW_HANCLINGTON;
-    if (strcmp(scene_id, "NEW_HANCLINGTON") == 0) return SCENE_NEW_HANCLINGTON;
-    if (strcmp(scene_id, "DETROIT_CORE") == 0) return SCENE_NEW_HANCLINGTON;
-    if (strcmp(scene_id, "SCENE_DETROIT_CORE") == 0) return SCENE_NEW_HANCLINGTON;
-    if (strcmp(scene_id, "SCENE_CITY") == 0) return SCENE_NEW_HANCLINGTON;
+    if (strcmp(scene_id, "TOWN") == 0) return SCENE_CITY;
+    if (strcmp(scene_id, "SCENE_CITY") == 0) return SCENE_CITY;
     if (strcmp(scene_id, "WAREHOUSE") == 0) return SCENE_WAREHOUSE;
     if (strcmp(scene_id, "SCENE_WAREHOUSE") == 0) return SCENE_WAREHOUSE;
     if (strcmp(scene_id, "MINES") == 0) return SCENE_MINES;
@@ -2671,11 +2668,11 @@ int main(int argc, char* argv[]) {
     telecrystal_reset_runtime();
     lobby_init_labels();
     printf("[SCENE] startup request=GARAGE_OSAKA resolved=%s (%d)\n", scene_id_name(SCENE_GARAGE_OSAKA), SCENE_GARAGE_OSAKA);
-#if DEBUG_BOOT_NEW_HANCLINGTON
+#if DEBUG_BOOT_TOWN
     app_state = STATE_GAME_LOCAL;
-    scene_load(SCENE_NEW_HANCLINGTON);
-    printf("[SCENE] startup request=DEBUG_BOOT_NEW_HANCLINGTON resolved=%s (%d)\n",
-           scene_id_name(SCENE_NEW_HANCLINGTON), SCENE_NEW_HANCLINGTON);
+    scene_load(SCENE_CITY);
+    printf("[SCENE] startup request=DEBUG_BOOT_TOWN resolved=%s (%d)\n",
+           scene_id_name(SCENE_CITY), SCENE_CITY);
 #endif
     ui_bridge_init("127.0.0.1", 17777);
     if (ui_bridge_fetch_state(&ui_state)) {
@@ -2819,7 +2816,7 @@ int main(int argc, char* argv[]) {
                 if (e.type == SDL_KEYDOWN) {
                     crisis_mock_state_handle_key(&crisis_mock_state, e.key.keysym.sym);
                     if (e.key.keysym.sym == SDLK_F9) {
-                        scene_load(SCENE_NEW_HANCLINGTON);
+                        scene_load(SCENE_CITY);
                     }
                 }
                 if(e.type == SDL_KEYDOWN && e.key.keysym.sym == SDLK_ESCAPE) {

--- a/docs2/specs/SCENE_REGISTRY_SPEC.md
+++ b/docs2/specs/SCENE_REGISTRY_SPEC.md
@@ -7,7 +7,7 @@ Canonical scene IDs and aliases.
 | `SCENE_GARAGE_OSAKA` | 0 | GARAGE_OSAKA | `GARAGE_OSAKA` |
 | `SCENE_STADIUM` | 1 | STADIUM | `STADIUM` |
 | `SCENE_VOXWORLD` | 2 | VOXWORLD | `VOXWORLD` |
-| `SCENE_CITY` (`SCENE_NEW_HANCLINGTON`) | 3 | NEW_HANCLINGTON | `NEW_HANCLINGTON_MOCKUP`, `NEW_HANCLINGTON`, `SCENE_CITY` |
+| `SCENE_CITY` | 3 | TOWN | `TOWN`, `SCENE_CITY` |
 | `SCENE_MINES` | 4 | MINES | `MINES`, `SCENE_MINES` |
 | `SCENE_WAREHOUSE` | 5 | WAREHOUSE | `WAREHOUSE`, `SCENE_WAREHOUSE` |
 | `SCENE_DOCKS` | 6 | DOCKS | `DOCKS`, `SCENE_DOCKS` |
@@ -16,3 +16,7 @@ Implementation surfaces:
 - `scene_id_name(scene_id)`
 - `lobby_resolve_scene_id(scene_id_string)`
 - `scene_load(scene_id)` + `phys_set_scene(scene_id)`
+
+Notes:
+- `SCENE_CITY` is the authoritative Town world scene.
+- Legacy compile-time aliases (`SCENE_NEW_HANCLINGTON`, `SCENE_DETROIT_CORE`) remain defined in code, but registry routing should target `TOWN`/`SCENE_CITY`.

--- a/packages/common/protocol.h
+++ b/packages/common/protocol.h
@@ -15,6 +15,7 @@
 #define SCENE_WAREHOUSE 5
 #define SCENE_DOCKS 6
 #define SCENE_GIZA_PLATEAU 7
+/* Legacy aliases kept for build compatibility only. */
 #define SCENE_NEW_HANCLINGTON SCENE_CITY
 #define SCENE_DETROIT_CORE SCENE_CITY
 
@@ -23,7 +24,7 @@ static inline const char *scene_id_name(int scene_id) {
         case SCENE_GARAGE_OSAKA: return "SCENE_GARAGE_OSAKA";
         case SCENE_STADIUM: return "SCENE_STADIUM";
         case SCENE_VOXWORLD: return "SCENE_VOXWORLD";
-        case SCENE_CITY: return "SCENE_DETROIT_CORE";
+        case SCENE_CITY: return "SCENE_CITY";
         case SCENE_MINES: return "SCENE_MINES";
         case SCENE_WAREHOUSE: return "WAREHOUSE";
         case SCENE_DOCKS: return "DOCKS";

--- a/packages/world/town_map.c
+++ b/packages/world/town_map.c
@@ -3,42 +3,42 @@
 #define TOWN_WORLD_SCALE 3.0f
 
 static const TownBuilding g_buildings[] = {
-    {BLD_AUCTION_HOUSE, "Campus Tower", 60, 52, 20, 16, 24, 0},
-    {BLD_TOWN_HALL, "Civic Hall", 60, 60, 12, 10, 16, 0},
-    {BLD_GUILD_HOUSE, "Grand Ave South Lobby", 46, 46, 18, 12, 12, 0},
-    {BLD_GOLD_GUILD, "Grand Ave North Lobby", 62, 82, 16, 12, 12, 0},
-    {BLD_POST_OFFICE, "Brush Row North", 14, 96, 16, 14, 10, 0},
-    {BLD_BLACKSMITH, "Brush Row Court", 24, 112, 16, 12, 10, 0},
-    {BLD_WEAPONS_GUILD, "Brush Hall", 16, 136, 24, 16, 14, 0},
-    {BLD_POTIONS, "Stadium Concourse", 82, 132, 26, 18, 16, 0},
-    {BLD_ALCHEMY_SHOP, "Event Plaza Hall", 96, 124, 18, 14, 12, 0},
-    {BLD_SHADY_DEALER, "Arena Garage", 98, 92, 24, 24, 16, 0},
-    {BLD_FISH_SHOP, "Warehouse Bay A", 8, 54, 28, 16, 12, 0},
-    {BLD_ARMOR_SHOP, "Warehouse Bay B", 8, 74, 26, 16, 12, 0},
-    {BLD_MINECO_OPS, "Utility Annex", 22, 78, 14, 10, 8, 0},
-    {BLD_MINING_SUPPLIES, "Utility Garage", 22, 50, 14, 10, 8, 0},
-    {BLD_ARCHERY_GUILD, "Financial Podium", 118, 42, 22, 16, 18, 0},
-    {BLD_POLICE, "Riverward Core", 134, 34, 20, 18, 20, 0},
-    {BLD_GLOVE_SHOP, "Congress Exchange", 110, 22, 18, 14, 14, 0},
+    {BLD_AUCTION_HOUSE, "Auction House", 60, 58, 20, 16, 24, 0},
+    {BLD_TOWN_HALL, "Town Hall", 60, 70, 14, 12, 18, 0},
+    {BLD_GUILD_HOUSE, "Guild House", 44, 50, 18, 12, 12, 0},
+    {BLD_GOLD_GUILD, "Gold Guild", 76, 86, 16, 12, 12, 0},
+    {BLD_POST_OFFICE, "Post Office", 18, 102, 16, 14, 10, 0},
+    {BLD_BLACKSMITH, "Blacksmith", 24, 120, 16, 12, 10, 0},
+    {BLD_WEAPONS_GUILD, "Weapons Guild", 18, 150, 24, 16, 14, 0},
+    {BLD_POTIONS, "Potions Shop", 90, 138, 26, 18, 16, 0},
+    {BLD_ALCHEMY_SHOP, "Alchemy Shop", 106, 130, 18, 14, 12, 0},
+    {BLD_SHADY_DEALER, "Back Alley Market", 106, 98, 24, 24, 16, 0},
+    {BLD_FISH_SHOP, "Fishmonger", 6, 62, 28, 16, 12, 0},
+    {BLD_ARMOR_SHOP, "Armor Shop", 8, 82, 26, 16, 12, 0},
+    {BLD_MINECO_OPS, "Mining Co-op", 24, 88, 14, 10, 8, 0},
+    {BLD_MINING_SUPPLIES, "Mining Supplies", 26, 54, 14, 10, 8, 0},
+    {BLD_ARCHERY_GUILD, "Archery Guild", 132, 38, 22, 16, 18, 0},
+    {BLD_POLICE, "Town Watch", 148, 30, 20, 18, 20, 0},
+    {BLD_GLOVE_SHOP, "Market Exchange", 120, 18, 18, 14, 14, 0},
 };
 
 static const CrisisSocket g_sockets[] = {
-    {SOCK_ANCHOR_AUCTION, "Anchor: CAMPUS PLAZA", 60, 58, 3.5f, SOCK_ROLE_BUILDER, 1},
-    {SOCK_RITUAL_TOWN_HALL, "Anchor: GRAND AVENUE", 60, 86, 3.5f, SOCK_ROLE_RITUALIST, 1},
-    {SOCK_INTERCEPT_DOCK_ROUTE, "Anchor: STADIUM DISTRICT", 96, 132, 4.0f, SOCK_ROLE_STRIKE | SOCK_ROLE_SCOUT, 1},
-    {SOCK_INTERCEPT_MINES_ROUTE, "Anchor: FINANCIAL EDGE", 120, 24, 4.0f, SOCK_ROLE_STRIKE | SOCK_ROLE_SCOUT, 1},
-    {SOCK_HEAD_A_DOCKS, "Anchor: WAREHOUSE EDGE", 8, 62, 4.5f, SOCK_ROLE_STRIKE, 0},
-    {SOCK_HEAD_B_MINES, "Anchor: BRUSH BLOCKS", 16, 112, 4.5f, SOCK_ROLE_STRIKE, 0},
-    {SOCK_SECRET_GATE_PRESSURE, "Anchor: RIVER GATE", 142, 18, 3.0f, SOCK_ROLE_SCOUT, 1}
+    {SOCK_ANCHOR_AUCTION, "Anchor: AUCTION SQUARE", 60, 58, 3.5f, SOCK_ROLE_BUILDER, 1},
+    {SOCK_RITUAL_TOWN_HALL, "Anchor: TOWN HALL", 60, 86, 3.5f, SOCK_ROLE_RITUALIST, 1},
+    {SOCK_INTERCEPT_DOCK_ROUTE, "Anchor: STADIUM ROAD", 96, 138, 4.0f, SOCK_ROLE_STRIKE | SOCK_ROLE_SCOUT, 1},
+    {SOCK_INTERCEPT_MINES_ROUTE, "Anchor: MARKET WAY", 120, 24, 4.0f, SOCK_ROLE_STRIKE | SOCK_ROLE_SCOUT, 1},
+    {SOCK_HEAD_A_DOCKS, "Anchor: WATERFRONT GATE", 8, 62, 4.5f, SOCK_ROLE_STRIKE, 0},
+    {SOCK_HEAD_B_MINES, "Anchor: BRUSH GATE", 16, 118, 4.5f, SOCK_ROLE_STRIKE, 0},
+    {SOCK_SECRET_GATE_PRESSURE, "Anchor: RIVER GATE", 146, 18, 3.0f, SOCK_ROLE_SCOUT, 1}
 };
 
 static const TownRoutePoint g_routes[] = {
-    {"Campus Plaza", 60, 58},
-    {"Grand Avenue", 60, 86},
-    {"Stadium District", 96, 132},
-    {"Brush Blocks", 20, 114},
-    {"Warehouse Edge", 8, 62},
-    {"Financial Edge", 120, 24}
+    {"Auction Square", 60, 58},
+    {"Town Hall Way", 60, 86},
+    {"Stadium Road", 96, 138},
+    {"Brush Blocks", 20, 120},
+    {"Waterfront Gate", 8, 62},
+    {"Market Way", 120, 24}
 };
 
 static TownBuilding g_buildings_scaled[sizeof(g_buildings) / sizeof(g_buildings[0])];

--- a/packages/world/town_render.c
+++ b/packages/world/town_render.c
@@ -174,12 +174,12 @@ int town_render_collect_labels(const CrisisMockState *state,
         float x, y, z;
         TownLabelMode mode;
     } district_labels[] = {
-        {"CAMPUS PLAZA", 180.0f, 22.0f, 176.0f, TOWN_LABEL_LANDMARK},
-        {"GRAND AVENUE", 180.0f, 20.0f, 320.0f, TOWN_LABEL_ROUTE},
+        {"AUCTION SQUARE", 180.0f, 22.0f, 176.0f, TOWN_LABEL_LANDMARK},
+        {"TOWN HALL WAY", 180.0f, 20.0f, 320.0f, TOWN_LABEL_ROUTE},
         {"STADIUM DISTRICT", 248.0f, 30.0f, 420.0f, TOWN_LABEL_LANDMARK},
         {"BRUSH BLOCKS", 38.0f, 24.0f, 420.0f, TOWN_LABEL_ROUTE},
-        {"WAREHOUSE EDGE", -104.0f, 20.0f, 168.0f, TOWN_LABEL_ROUTE},
-        {"FINANCIAL EDGE", 360.0f, 30.0f, 48.0f, TOWN_LABEL_LANDMARK},
+        {"WATERFRONT GATE", -104.0f, 20.0f, 168.0f, TOWN_LABEL_ROUTE},
+        {"MARKET WAY", 360.0f, 30.0f, 48.0f, TOWN_LABEL_LANDMARK},
         {"CIVIC CORE", 180.0f, 18.0f, 124.0f, TOWN_LABEL_GATE}
     };
     for (size_t i = 0; i < sizeof(district_labels) / sizeof(district_labels[0]) && out_count < max_labels; i++) {


### PR DESCRIPTION
### Motivation
- Re-establish `SCENE_CITY` as the authoritative Town world so the Town scene is no longer treated or branded as the Detroit Core / New Hanclington experiment. 
- Remove accidental cross-scene routing and UI naming that caused mixed town/platform identity and travel/anchor confusion.
- Make the Town world data and labels explicitly Town-native so the scene is a coherent single authored world before any expansion work.

### Description
- Made `scene_id_name(SCENE_CITY)` return `"SCENE_CITY"` and documented legacy aliases in `packages/common/protocol.h` so `SCENE_NEW_HANCLINGTON` / `SCENE_DETROIT_CORE` remain compile-time aliases only. 
- Updated lobby routing/UI in `apps/lobby/src/main.c` to resolve and present Town via the `"TOWN"`/`SCENE_CITY` identifiers, replaced the lobby label from "Detroit Core" to "Town", and switched debug boot / F9 quick-load defines to `DEBUG_BOOT_TOWN` / `SCENE_CITY`. 
- Restored Town-specific map language and anchors in `packages/world/town_map.c` by renaming buildings, route points, and crisis socket anchor labels/positions to Town-native names and placements. 
- Updated in-world district labels in `packages/world/town_render.c` to match the restored Town identity. 
- Updated the scene registry spec `docs2/specs/SCENE_REGISTRY_SPEC.md` to mark `SCENE_CITY` as the authoritative Town scene and note legacy aliases are compatibility-only.

### Testing
- Ran `make server` which built the game server binary successfully. 
- Attempted `make lobby` which failed in this environment due to missing SDL2 development headers (`SDL2/SDL.h` and `SDL2/SDL_opengl.h`), so the lobby client could not be built here. 
- No runtime QA screenshots were produced in this environment; textual build verification and compilation of server were successful.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d559899b188327aa04b005a26a191b)