### PR TITLE
Fix town street/apron slabs clipping through players

### DIFF
--- a/packages/common/physics.h
+++ b/packages/common/physics.h
@@ -103,14 +103,14 @@ static const Box map_geo_city[] = {
     {650.0f, 30.0f, 180.0f, 14.0f, 60.0f, 940.0f},
 
     // Primary streets and plazas (single coherent traversal grid)
-    {180.0f, 0.6f, 180.0f, 120.0f, 1.2f, 820.0f}, // Grand Avenue spine
-    {180.0f, 0.6f, 176.0f, 340.0f, 1.2f, 120.0f}, // Civic plaza east-west
-    {180.0f, 0.6f, 300.0f, 760.0f, 1.2f, 96.0f},  // Midtown connector
-    {180.0f, 0.6f, 424.0f, 760.0f, 1.2f, 96.0f},  // North connector
-    {60.0f, 0.6f, 180.0f, 96.0f, 1.2f, 560.0f},   // West arterial
-    {300.0f, 0.6f, 180.0f, 96.0f, 1.2f, 560.0f},  // East arterial
-    {-70.0f, 0.6f, 176.0f, 200.0f, 1.2f, 420.0f}, // Warehouse edge routes
-    {430.0f, 0.6f, 82.0f, 220.0f, 1.2f, 240.0f},  // Financial edge routes
+    {180.0f, -0.6f, 180.0f, 120.0f, 1.2f, 820.0f}, // Grand Avenue spine
+    {180.0f, -0.6f, 176.0f, 340.0f, 1.2f, 120.0f}, // Civic plaza east-west
+    {180.0f, -0.6f, 300.0f, 760.0f, 1.2f, 96.0f},  // Midtown connector
+    {180.0f, -0.6f, 424.0f, 760.0f, 1.2f, 96.0f},  // North connector
+    {60.0f, -0.6f, 180.0f, 96.0f, 1.2f, 560.0f},   // West arterial
+    {300.0f, -0.6f, 180.0f, 96.0f, 1.2f, 560.0f},  // East arterial
+    {-70.0f, -0.6f, 176.0f, 200.0f, 1.2f, 420.0f}, // Warehouse edge routes
+    {430.0f, -0.6f, 82.0f, 220.0f, 1.2f, 240.0f},  // Financial edge routes
 
     // Civic core district
     {180.0f, 8.0f, 176.0f, 40.0f, 16.0f, 40.0f},
@@ -150,13 +150,13 @@ static const Box map_geo_city[] = {
     {398.0f, 12.0f, 118.0f, 110.0f, 24.0f, 56.0f},
 
     // Town expansion districts (south and far north), connected by streets
-    {180.0f, 0.6f, 28.0f, 520.0f, 1.2f, 96.0f},
+    {180.0f, -0.6f, 28.0f, 520.0f, 1.2f, 96.0f},
     {48.0f, 8.0f, 20.0f, 56.0f, 16.0f, 40.0f},
     {120.0f, 9.0f, 24.0f, 60.0f, 18.0f, 44.0f},
     {240.0f, 9.0f, 24.0f, 60.0f, 18.0f, 44.0f},
     {320.0f, 8.0f, 20.0f, 56.0f, 16.0f, 40.0f},
 
-    {180.0f, 0.6f, 548.0f, 560.0f, 1.2f, 96.0f},
+    {180.0f, -0.6f, 548.0f, 560.0f, 1.2f, 96.0f},
     {72.0f, 8.0f, 548.0f, 56.0f, 16.0f, 44.0f},
     {148.0f, 9.0f, 548.0f, 60.0f, 18.0f, 46.0f},
     {228.0f, 9.0f, 548.0f, 60.0f, 18.0f, 46.0f},

--- a/packages/world/town_render.c
+++ b/packages/world/town_render.c
@@ -215,17 +215,17 @@ void town_render_world(const CrisisMockState *state) {
     }
 
     draw_box(180.0f, -4.5f, 180.0f, 860.0f, 9.0f, 860.0f, 0.03f, 0.03f, 0.04f);
-    draw_box(180.0f, 6.0f, 180.0f, 120.0f, 12.0f, 760.0f, 0.11f, 0.12f, 0.14f); // grand avenue
-    draw_box(180.0f, 1.2f, 176.0f, 132.0f, 2.4f, 120.0f, 0.16f, 0.16f, 0.18f); // civic plaza
-    draw_box(248.0f, 2.0f, 390.0f, 248.0f, 4.0f, 196.0f, 0.14f, 0.14f, 0.15f); // stadium/event apron
-    draw_box(300.0f, 4.0f, 68.0f, 196.0f, 8.0f, 150.0f, 0.10f, 0.11f, 0.14f);  // financial podium
-    draw_box(-96.0f, 2.0f, 168.0f, 164.0f, 4.0f, 198.0f, 0.11f, 0.10f, 0.10f);  // warehouse apron
+    draw_box(180.0f, -0.6f, 180.0f, 120.0f, 1.2f, 760.0f, 0.11f, 0.12f, 0.14f); // grand avenue (ground-level)
+    draw_box(180.0f, -0.6f, 176.0f, 132.0f, 1.2f, 120.0f, 0.16f, 0.16f, 0.18f); // civic plaza (ground-level)
+    draw_box(248.0f, -0.6f, 390.0f, 248.0f, 1.2f, 196.0f, 0.14f, 0.14f, 0.15f); // stadium/event apron (ground-level)
+    draw_box(300.0f, -0.6f, 68.0f, 196.0f, 1.2f, 150.0f, 0.10f, 0.11f, 0.14f);  // financial podium (ground-level)
+    draw_box(-96.0f, -0.6f, 168.0f, 164.0f, 1.2f, 198.0f, 0.11f, 0.10f, 0.10f);  // warehouse apron (ground-level)
 
     draw_box_outline(180.0f, -4.5f, 180.0f, 860.0f, 9.0f, 860.0f, 0.18f, 0.90f, 0.92f, 1.4f);
-    draw_box_outline(180.0f, 6.0f, 180.0f, 120.0f, 12.0f, 760.0f, 0.98f, 0.78f, 0.25f, 1.4f);
-    draw_box_outline(180.0f, 1.2f, 176.0f, 132.0f, 2.4f, 120.0f, 0.30f, 0.94f, 0.94f, 1.8f);
-    draw_box_outline(248.0f, 2.0f, 390.0f, 248.0f, 4.0f, 196.0f, 0.95f, 0.55f, 0.20f, 1.6f);
-    draw_box_outline(-96.0f, 2.0f, 168.0f, 164.0f, 4.0f, 198.0f, 0.35f, 0.88f, 0.95f, 1.6f);
+    draw_box_outline(180.0f, -0.6f, 180.0f, 120.0f, 1.2f, 760.0f, 0.98f, 0.78f, 0.25f, 1.4f);
+    draw_box_outline(180.0f, -0.6f, 176.0f, 132.0f, 1.2f, 120.0f, 0.30f, 0.94f, 0.94f, 1.8f);
+    draw_box_outline(248.0f, -0.6f, 390.0f, 248.0f, 1.2f, 196.0f, 0.95f, 0.55f, 0.20f, 1.6f);
+    draw_box_outline(-96.0f, -0.6f, 168.0f, 164.0f, 1.2f, 198.0f, 0.35f, 0.88f, 0.95f, 1.6f);
 
     size_t bcount = 0;
     const TownBuilding *b = town_map_buildings(&bcount);


### PR DESCRIPTION
### Motivation
- Remove a visual/physics mismatch where large town slabs rendered slightly above the floor produced a thin walkable platform that players could clip into. 
- Ensure rendered ground geometry and collision geometry share the same vertical position so bodies no longer intersect visual slabs.

### Description
- Lowered the major town surface meshes in `town_render_world` to ground level by changing their Y centers from positive heights to `-0.6f` and adjusted the corresponding outline calls in `packages/world/town_render.c`.
- Aligned the collision geometry in `map_geo_city` by shifting the street/plaza boxes' center Y from `0.6f` to `-0.6f` in `packages/common/physics.h` while keeping thickness values unchanged.
- The change affects grand avenue, civic plaza, stadium/event apron, financial podium, warehouse apron and matching outline/collision entries so traversal and rendering are flush.

### Testing
- Attempted `./run_tests` but the script was not executable in this environment (permission denied), so automated tests could not be run there.
- Attempted `make lobby` to compile the client and the build failed due to missing SDL2 development headers/libraries in the environment, so a full compile verification was not possible.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dab3ca4dd88327ac6014f63d72af27)