### PR TITLE
Add Architect’s Orb reality-manipulation vertical slice (Orb console, bindings, trial)

### DIFF
--- a/apps/lobby/src/main.c
+++ b/apps/lobby/src/main.c
@@ -74,6 +74,14 @@ float cam_pitch = 0.0f;
 float current_fov = 75.0f;
 CrisisMockState crisis_mock_state;
 EduScriptSystem edu_script_system;
+typedef struct {
+    float hound_x;
+    float hound_z;
+    float hound_patrol_phase;
+    unsigned int hound_slow_until_ms;
+    unsigned int hound_defeat_logged;
+} ArchitectTrialRuntime;
+static ArchitectTrialRuntime architect_trial = {56.0f, 48.0f, 0.0f, 0, 0};
 
 typedef struct {
     int id;
@@ -1790,6 +1798,40 @@ static void draw_garage_overlay(PlayerState *p) {
 
 static void draw_edu_world_entities(void) {
     if (local_state.scene_id != SCENE_GARAGE_OSAKA) return;
+    unsigned int now_ms = SDL_GetTicks();
+    edu_script_system.world.puppet_anim_t += 0.016f;
+    edu_script_system.world.enemy_count = edu_script_system.world.rift_hound_active ? 1 : 0;
+    if (edu_script_system.world.enemy_slowed[0] && now_ms > architect_trial.hound_slow_until_ms) {
+        architect_trial.hound_slow_until_ms = now_ms + 4000;
+    }
+    float to_player_x = local_state.players[0].x - architect_trial.hound_x;
+    float to_player_z = local_state.players[0].z - architect_trial.hound_z;
+    float dist = sqrtf(to_player_x * to_player_x + to_player_z * to_player_z);
+    if (edu_script_system.world.rift_hound_active && dist > 0.01f) {
+        float speed = (now_ms < architect_trial.hound_slow_until_ms) ? 0.03f : 0.08f;
+        architect_trial.hound_x += (to_player_x / dist) * speed;
+        architect_trial.hound_z += (to_player_z / dist) * speed;
+    }
+    if (edu_script_system.world.rift_hound_active &&
+        edu_script_system.world.enemy_marked[0] &&
+        edu_script_system.world.enemy_slowed[0] &&
+        edu_script_system.world.portal_open) {
+        edu_script_system.world.rift_hound_active = 0;
+        edu_script_system.world.enemy_count = 0;
+        if (!architect_trial.hound_defeat_logged) {
+            architect_trial.hound_defeat_logged = 1;
+            printf("[RIFT] hound defeated\n");
+        }
+    }
+
+    glPushMatrix();
+    glTranslatef(58.0f, 0.01f, 42.0f);
+    glColor3f(0.93f, 0.93f, 0.95f);
+    glBegin(GL_QUADS);
+    glVertex3f(-36.0f, 0.0f, -24.0f); glVertex3f(36.0f, 0.0f, -24.0f); glVertex3f(36.0f, 0.0f, 24.0f); glVertex3f(-36.0f, 0.0f, 24.0f);
+    glEnd();
+    glPopMatrix();
+
     glPushMatrix();
     glTranslatef(35.0f + (float)edu_script_system.world.crate_x, 1.0f, 25.0f);
     glColor3f(0.95f, 0.75f, 0.15f);
@@ -1801,12 +1843,64 @@ static void draw_edu_world_entities(void) {
 
     glPushMatrix();
     glTranslatef(80.0f, 0.5f, 30.0f);
-    glColor3f(edu_script_system.world.gate_open ? 0.2f : 0.95f, edu_script_system.world.gate_open ? 0.9f : 0.3f, 0.2f);
+    glColor3f(edu_script_system.world.gate_open ? 0.70f : 0.95f, edu_script_system.world.gate_open ? 0.78f : 0.38f, 0.88f);
     glBegin(GL_QUADS);
     float gate_h = edu_script_system.world.gate_open ? 1.0f : 8.0f;
     glVertex3f(-8.0f, 0.0f, 0.0f); glVertex3f(8.0f, 0.0f, 0.0f); glVertex3f(8.0f, gate_h, 0.0f); glVertex3f(-8.0f, gate_h, 0.0f);
     glEnd();
     glPopMatrix();
+
+    glPushMatrix();
+    glTranslatef(67.0f, 0.3f, 35.0f);
+    glRotatef((float)edu_script_system.world.bridge_angle, 0.0f, 0.0f, 1.0f);
+    glColor3f(0.86f, 0.84f, 0.95f);
+    glBegin(GL_QUADS);
+    glVertex3f(-10.0f, 0.0f, -2.0f); glVertex3f(10.0f, 0.0f, -2.0f); glVertex3f(10.0f, 0.0f, 2.0f); glVertex3f(-10.0f, 0.0f, 2.0f);
+    glEnd();
+    glPopMatrix();
+
+    glPushMatrix();
+    glTranslatef(92.0f, 0.0f, 46.0f);
+    glColor3f(0.76f, 0.73f, 0.86f);
+    glBegin(GL_LINE_LOOP);
+    for (int seg = 0; seg < 36; seg++) {
+        float a = ((float)seg / 36.0f) * 6.2831853f;
+        glVertex3f(cosf(a) * 6.0f, 5.0f + sinf(a * 2.0f) * 0.1f, sinf(a) * 1.1f);
+    }
+    glEnd();
+    if (edu_script_system.world.portal_open) {
+        float pulse = 0.6f + 0.4f * sinf((float)now_ms * 0.01f);
+        glColor3f(0.92f, 0.85f + pulse * 0.1f, 1.0f);
+        glBegin(GL_QUADS);
+        glVertex3f(-4.0f, 1.0f, 0.0f); glVertex3f(4.0f, 1.0f, 0.0f); glVertex3f(4.0f, 9.0f, 0.0f); glVertex3f(-4.0f, 9.0f, 0.0f);
+        glEnd();
+    }
+    glPopMatrix();
+
+    if (edu_script_system.world.puppet_active) {
+        float y = 1.2f + sinf(edu_script_system.world.puppet_anim_t * 1.6f) * 0.25f;
+        glPushMatrix();
+        glTranslatef(edu_script_system.world.puppet_x, y, edu_script_system.world.puppet_z);
+        glColor3f(0.95f, 0.92f, 1.0f);
+        glBegin(GL_QUADS);
+        glVertex3f(-0.8f, 0.0f, -0.8f); glVertex3f(0.8f, 0.0f, -0.8f); glVertex3f(0.8f, 2.5f, -0.8f); glVertex3f(-0.8f, 2.5f, -0.8f);
+        glEnd();
+        glPopMatrix();
+    }
+
+    if (edu_script_system.world.rift_hound_active) {
+        glPushMatrix();
+        glTranslatef(architect_trial.hound_x, 0.2f, architect_trial.hound_z);
+        glColor3f(0.08f, 0.08f, 0.1f);
+        glBegin(GL_QUADS);
+        glVertex3f(-1.8f, 0.0f, -3.0f); glVertex3f(1.8f, 0.0f, -3.0f); glVertex3f(2.2f, 1.1f, 2.8f); glVertex3f(-2.2f, 1.1f, 2.8f);
+        glEnd();
+        glColor3f(edu_script_system.world.enemy_marked[0] ? 1.0f : 0.95f, 0.18f, 0.6f);
+        glBegin(GL_QUADS);
+        glVertex3f(-0.4f, 0.5f, 2.8f); glVertex3f(0.4f, 0.5f, 2.8f); glVertex3f(0.4f, 1.0f, 2.8f); glVertex3f(-0.4f, 1.0f, 2.8f);
+        glEnd();
+        glPopMatrix();
+    }
 }
 
 static void draw_edu_terminal_overlay(void) {
@@ -1818,11 +1912,11 @@ static void draw_edu_terminal_overlay(void) {
     glOrtho(0, 1280, 0, 720, -1, 1);
     glMatrixMode(GL_MODELVIEW); glPushMatrix(); glLoadIdentity();
 
-    glColor4f(0.05f, 0.08f, 0.12f, 0.95f);
+    glColor4f(0.95f, 0.94f, 0.99f, 0.96f);
     glRectf(120.0f, 80.0f, 1160.0f, 660.0f);
-    glColor3f(0.2f, 1.0f, 0.9f);
-    draw_string("EDU SHRINE TERMINAL [F6 toggle | F7 compile | F8 run | F9 reset | TAB slot]", 140, 630, 4);
-    glColor3f(0.9f, 0.95f, 1.0f);
+    glColor3f(0.52f, 0.41f, 0.72f);
+    draw_string("ARCHITECT'S ORB [F6 toggle | F7 compile | F8 run | F9 reset | TAB slot]", 140, 630, 4);
+    glColor3f(0.42f, 0.38f, 0.50f);
     draw_string(slot->name, 140, 605, 5);
     draw_string(slot->source, 140, 560, 4);
 
@@ -1833,11 +1927,12 @@ static void draw_edu_terminal_overlay(void) {
     glColor3f(0.8f, 0.8f, 1.0f);
     draw_string(edu_script_system.last_output, 140, 110, 4);
 
-    char world_line[196];
-    snprintf(world_line, sizeof(world_line), "crate_x=%d speed=%d gate=%d switch=%d quest(move/fall/gate)=%d/%d/%d instr=%d",
-             edu_script_system.world.crate_x, edu_script_system.world.crate_speed, edu_script_system.world.gate_open,
-             edu_script_system.world.switch_on, edu_script_system.world.quest_make_it_move, edu_script_system.world.quest_stop_the_fall,
-             edu_script_system.world.quest_open_the_gate, edu_script_system.last_instruction_count);
+    char world_line[256];
+    snprintf(world_line, sizeof(world_line),
+             "gate=%d bridge=%d portal=%d stable=%d enemies=%d trial=%d instr=%d",
+             edu_script_system.world.gate_open, edu_script_system.world.bridge_raised, edu_script_system.world.portal_open,
+             edu_script_system.world.portal_stability, edu_script_system.world.enemy_count, edu_script_system.world.trial_complete,
+             edu_script_system.last_instruction_count);
     glColor3f(0.65f, 0.95f, 0.95f);
     draw_string(world_line, 140, 90, 4);
 

--- a/packages/education/edu_bindings.c
+++ b/packages/education/edu_bindings.c
@@ -21,6 +21,14 @@ static const BuiltinDef G_BUILTINS[] = {
     {"get_quest_state", EDU_BUILTIN_GET_QUEST_STATE, 1},
     {"print", EDU_BUILTIN_PRINT, 1},
     {"show_message", EDU_BUILTIN_SHOW_MESSAGE, 1},
+    {"scan_gate", EDU_BUILTIN_SCAN_GATE, 0},
+    {"scan_portal", EDU_BUILTIN_SCAN_PORTAL, 0},
+    {"scan_enemy_count", EDU_BUILTIN_SCAN_ENEMY_COUNT, 0},
+    {"raise_bridge", EDU_BUILTIN_RAISE_BRIDGE, 0},
+    {"stabilize_portal", EDU_BUILTIN_STABILIZE_PORTAL, 1},
+    {"open_portal", EDU_BUILTIN_OPEN_PORTAL, 0},
+    {"mark_enemy", EDU_BUILTIN_MARK_ENEMY, 1},
+    {"slow_enemy", EDU_BUILTIN_SLOW_ENEMY, 1},
 };
 
 int edu_binding_lookup(const char *name, int name_len, int *out_id, int *out_argc) {
@@ -44,6 +52,7 @@ int edu_binding_call(EduWorldState *world, int builtin_id, const int *args, int 
                      char *debug_out, int debug_cap) {
     (void)argc;
     *out_ret = 0;
+#define EDU_FORBIDDEN(msg) do { snprintf(debug_out, (size_t)debug_cap, "forbidden: %s", msg); return 0; } while (0)
     switch (builtin_id) {
         case EDU_BUILTIN_SET_CRATE_SPEED:
             world->crate_speed = args[0];
@@ -59,8 +68,10 @@ int edu_binding_call(EduWorldState *world, int builtin_id, const int *args, int 
             snprintf(debug_out, (size_t)debug_cap, "stop_crate");
             return 1;
         case EDU_BUILTIN_OPEN_GATE:
+            if (!world->can_open_gate) EDU_FORBIDDEN("open_gate capability locked");
             world->gate_open = 1;
             world->quest_open_the_gate = 1;
+            printf("[REALITY] gate opened\n");
             snprintf(debug_out, (size_t)debug_cap, "open_gate");
             return 1;
         case EDU_BUILTIN_CLOSE_GATE:
@@ -97,6 +108,60 @@ int edu_binding_call(EduWorldState *world, int builtin_id, const int *args, int 
             snprintf(debug_out, (size_t)debug_cap, "get_quest_state(%s) -> %d", id, *out_ret);
             return 1;
         }
+        case EDU_BUILTIN_SCAN_GATE:
+            *out_ret = world->gate_open ? 1 : 0;
+            snprintf(debug_out, (size_t)debug_cap, "scan_gate -> %d", *out_ret);
+            return 1;
+        case EDU_BUILTIN_SCAN_PORTAL:
+            *out_ret = world->portal_stability;
+            snprintf(debug_out, (size_t)debug_cap, "scan_portal -> %d", *out_ret);
+            return 1;
+        case EDU_BUILTIN_SCAN_ENEMY_COUNT:
+            *out_ret = world->enemy_count;
+            snprintf(debug_out, (size_t)debug_cap, "scan_enemy_count -> %d", *out_ret);
+            return 1;
+        case EDU_BUILTIN_RAISE_BRIDGE:
+            if (!world->can_raise_bridge) EDU_FORBIDDEN("raise_bridge capability locked");
+            world->bridge_raised = 1;
+            world->bridge_angle = 35;
+            printf("[REALITY] bridge raised\n");
+            snprintf(debug_out, (size_t)debug_cap, "raise_bridge");
+            return 1;
+        case EDU_BUILTIN_STABILIZE_PORTAL: {
+            if (!world->can_modify_portal) EDU_FORBIDDEN("stabilize_portal capability locked");
+            int amount = args[0];
+            if (amount < 0) amount = 0;
+            world->portal_stability += amount;
+            if (world->portal_stability > 150) world->portal_stability = 150;
+            printf("[REALITY] portal stability=%d\n", world->portal_stability);
+            snprintf(debug_out, (size_t)debug_cap, "stabilize_portal(%d) -> %d", args[0], world->portal_stability);
+            return 1;
+        }
+        case EDU_BUILTIN_OPEN_PORTAL:
+            if (!world->can_modify_portal) EDU_FORBIDDEN("open_portal capability locked");
+            if (world->portal_stability < 100) EDU_FORBIDDEN("portal stability below threshold 100");
+            world->portal_open = 1;
+            if (world->gate_open && world->bridge_raised) world->trial_complete = 1;
+            printf("[REALITY] portal opened\n");
+            snprintf(debug_out, (size_t)debug_cap, "open_portal");
+            return 1;
+        case EDU_BUILTIN_MARK_ENEMY: {
+            if (!world->can_affect_enemies) EDU_FORBIDDEN("mark_enemy capability locked");
+            int idx = args[0];
+            if (idx < 0 || idx >= 4 || idx >= world->enemy_count) EDU_FORBIDDEN("enemy index out of range");
+            world->enemy_marked[idx] = 1;
+            snprintf(debug_out, (size_t)debug_cap, "mark_enemy(%d)", idx);
+            return 1;
+        }
+        case EDU_BUILTIN_SLOW_ENEMY: {
+            if (!world->can_affect_enemies) EDU_FORBIDDEN("slow_enemy capability locked");
+            int idx = args[0];
+            if (idx < 0 || idx >= 4 || idx >= world->enemy_count) EDU_FORBIDDEN("enemy index out of range");
+            world->enemy_slowed[idx] = 1;
+            printf("[RIFT] hound slowed\n");
+            snprintf(debug_out, (size_t)debug_cap, "slow_enemy(%d)", idx);
+            return 1;
+        }
         case EDU_BUILTIN_PRINT:
             world->last_print = args[0];
             snprintf(debug_out, (size_t)debug_cap, "print(%d)", args[0]);
@@ -111,4 +176,5 @@ int edu_binding_call(EduWorldState *world, int builtin_id, const int *args, int 
             snprintf(debug_out, (size_t)debug_cap, "unknown builtin=%d", builtin_id);
             return 0;
     }
+#undef EDU_FORBIDDEN
 }

--- a/packages/education/edu_bindings.h
+++ b/packages/education/edu_bindings.h
@@ -5,11 +5,32 @@ typedef struct {
     int crate_speed;
     int crate_x;
     int gate_open;
+    int bridge_raised;
+    int bridge_angle;
+    int portal_stability;
+    int portal_open;
+    int enemy_count;
+    int trial_complete;
     int switch_on;
     int grounded_test_platform;
     int quest_make_it_move;
     int quest_stop_the_fall;
     int quest_open_the_gate;
+    int rift_hound_active;
+    int rift_hound_hp;
+    int enemy_marked[4];
+    int enemy_slowed[4];
+    int can_open_gate;
+    int can_raise_bridge;
+    int can_modify_portal;
+    int can_affect_enemies;
+    int can_spawn_entities;
+    int puppet_active;
+    int puppet_type;
+    float puppet_x;
+    float puppet_y;
+    float puppet_z;
+    float puppet_anim_t;
     int last_print;
     char last_message[96];
 } EduWorldState;
@@ -27,6 +48,14 @@ typedef enum {
     EDU_BUILTIN_GET_QUEST_STATE,
     EDU_BUILTIN_PRINT,
     EDU_BUILTIN_SHOW_MESSAGE,
+    EDU_BUILTIN_SCAN_GATE,
+    EDU_BUILTIN_SCAN_PORTAL,
+    EDU_BUILTIN_SCAN_ENEMY_COUNT,
+    EDU_BUILTIN_RAISE_BRIDGE,
+    EDU_BUILTIN_STABILIZE_PORTAL,
+    EDU_BUILTIN_OPEN_PORTAL,
+    EDU_BUILTIN_MARK_ENEMY,
+    EDU_BUILTIN_SLOW_ENEMY,
     EDU_BUILTIN_COUNT
 } EduBuiltinId;
 

--- a/packages/education/edu_script.c
+++ b/packages/education/edu_script.c
@@ -12,28 +12,48 @@ void edu_script_init(EduScriptSystem *sys) {
     memset(sys, 0, sizeof(*sys));
     sys->world.crate_speed = 1;
     sys->world.grounded_test_platform = 1;
+    sys->world.portal_stability = 25;
+    sys->world.enemy_count = 1;
+    sys->world.rift_hound_active = 1;
+    sys->world.rift_hound_hp = 100;
+    sys->world.can_open_gate = 1;
+    sys->world.can_raise_bridge = 1;
+    sys->world.can_modify_portal = 1;
+    sys->world.can_affect_enemies = 1;
+    sys->world.can_spawn_entities = 0;
+    sys->world.puppet_active = 1;
+    sys->world.puppet_type = 1;
+    sys->world.puppet_x = 64.0f;
+    sys->world.puppet_z = 53.0f;
+    printf("[RIFT] hound spawned\n");
     sys->active_slot = 0;
-    seed_script(&sys->slots[0], "Motion Terminal",
-                "let speed = 2;\n"
-                "set_crate_speed(speed);\n"
+    seed_script(&sys->slots[0], "Architect Trial Script",
+                "let stability = scan_portal();\n"
+                "if stability < 100 {\n"
+                "  stabilize_portal(50);\n"
+                "}\n"
+                "raise_bridge();\n"
+                "open_gate();\n"
+                "open_portal();\n"
+                "slow_enemy(0);\n"
+                "mark_enemy(0);\n");
+    seed_script(&sys->slots[1], "Orb Scan",
+                "let gate = scan_gate();\n"
+                "let portal = scan_portal();\n"
+                "let enemies = scan_enemy_count();\n"
+                "print(gate + portal + enemies);\n");
+    seed_script(&sys->slots[2], "Legacy Motion",
+                "set_crate_speed(2);\n"
                 "move_crate();\n"
-                "print(speed);\n");
-    seed_script(&sys->slots[1], "Gate Terminal",
-                "if is_switch_on() {\n"
-                "  open_gate();\n"
-                "} else {\n"
-                "  close_gate();\n"
-                "}\n");
-    seed_script(&sys->slots[2], "Collision Terminal",
-                "let grounded = query_grounded(\"test_platform\");\n"
-                "if grounded {\n"
-                "  mark_quest_complete(\"STOP_THE_FALL\");\n"
-                "}\n");
+                "print(7);\n");
     snprintf(sys->compile_status, sizeof(sys->compile_status), "idle");
     snprintf(sys->run_status, sizeof(sys->run_status), "idle");
 }
 
-void edu_script_toggle_terminal(EduScriptSystem *sys) { sys->terminal_open = !sys->terminal_open; }
+void edu_script_toggle_terminal(EduScriptSystem *sys) {
+    sys->terminal_open = !sys->terminal_open;
+    printf("[EDU_ORB] %s\n", sys->terminal_open ? "opened" : "closed");
+}
 
 void edu_script_reset_active(EduScriptSystem *sys) {
     EduScriptSlot *s = &sys->slots[sys->active_slot];
@@ -78,8 +98,10 @@ int edu_script_compile_active(EduScriptSystem *sys) {
     }
     if (ok) {
         snprintf(sys->compile_status, sizeof(sys->compile_status), "ok (%d bytes)", s->bytecode_len);
+        printf("[EDU_VM] compile ok bytes=%d slot=%d\n", s->bytecode_len, sys->active_slot);
     } else {
         snprintf(sys->compile_status, sizeof(sys->compile_status), "error %d:%d %.88s", out.error_line, out.error_col, out.error);
+        printf("[EDU_VM] compile error line=%d col=%d msg=%s\n", out.error_line, out.error_col, out.error);
     }
     return ok;
 }
@@ -99,14 +121,13 @@ int edu_script_run_active(EduScriptSystem *sys) {
     EduVmProgramMeta meta;
     meta.strings = s->strings;
     meta.string_count = s->string_count;
-    printf("[EDUSCRIPT] vm begin\n");
     int ok = edu_vm_exec(&vm, s->bytecode, s->bytecode_len, &meta, &sys->world, &lim, sys->run_status, (int)sizeof(sys->run_status));
     if (ok) {
         snprintf(sys->last_output, sizeof(sys->last_output), "%.96s | print=%d", vm.debug_line, sys->world.last_print);
-        printf("[EDUSCRIPT] vm halt instructions=%d\n", vm.instruction_count);
+        printf("[EDU_VM] run ok instruction_count=%d\n", vm.instruction_count);
     } else {
         snprintf(sys->last_output, sizeof(sys->last_output), "runtime failure");
-        if (lim.halted_due_to_limit) printf("[EDUSCRIPT] vm error limit exceeded\n");
+        printf("[EDU_VM] run error %s\n", sys->run_status);
     }
     sys->last_instruction_count = vm.instruction_count;
     return ok;

--- a/packages/education/edu_vm.c
+++ b/packages/education/edu_vm.c
@@ -153,7 +153,11 @@ int edu_vm_exec(EduVm *vm, const unsigned char *code, int code_len,
 
     limits->error_code = vm->last_error;
     if (vm->last_error) {
-        snprintf(out_msg, (size_t)out_msg_cap, "vm error=%d instr=%d", vm->last_error, vm->instruction_count);
+        if (vm->last_error == EDU_VM_ERR_BUILTIN && vm->debug_line[0]) {
+            snprintf(out_msg, (size_t)out_msg_cap, "vm builtin error: %s instr=%d", vm->debug_line, vm->instruction_count);
+        } else {
+            snprintf(out_msg, (size_t)out_msg_cap, "vm error=%d instr=%d", vm->last_error, vm->instruction_count);
+        }
         return 0;
     }
     snprintf(out_msg, (size_t)out_msg_cap, "vm halt instructions=%d ret=%d", vm->instruction_count, ret);


### PR DESCRIPTION
### Motivation
- Implement a first playable vertical slice where the in-world Architect’s Orb exposes the existing education VM to inspect and modify a tiny, safe reality state for an Architect Trial. 
- Provide visible, diegetic feedback (gate, bridge, portal, Rift Hound) so scripts running on the safe VM demonstrably change game state and can be used for tutorials and future content.

### Description
- Added explicit trial fields, capability flags, and a puppet seam to `EduWorldState` and wired new builtins: `scan_gate`, `scan_portal`, `scan_enemy_count`, `raise_bridge`, `stabilize_portal`, `open_portal`, `mark_enemy`, and `slow_enemy` in `packages/education/edu_bindings.{h,c}`. 
- Enforced simple hardcoded capability gating with readable forbidden errors and surfaced builtin failure text through the VM runtime message path in `packages/education/edu_vm.c`. 
- Seeded a tutorial Architect Trial script, default world values, logging, and Orb open/close + compile/run messages in `packages/education/edu_script.c`. 
- Implemented a localized Architect Trial presentation in the lobby client by adding a small runtime and draw/update code (platform, gate, bridge, portal effect, puppet placeholder, and a simple Rift Hound enemy that can be slowed/marked/defeated) and rethemed the terminal overlay to “ARCHITECT’S ORB” in `apps/lobby/src/main.c`.
- Files changed: `apps/lobby/src/main.c`, `packages/education/edu_bindings.h`, `packages/education/edu_bindings.c`, `packages/education/edu_script.c`, `packages/education/edu_vm.c`.
- Orb/VM/bindings/world-state path: the Orb UI toggles in the lobby (`F6`) and uses `edu_script_compile_active` (parser -> bytecode) and `edu_script_run_active` (calls `edu_vm_exec`), which dispatches to `edu_binding_call` that mutates `EduWorldState`; render/update reads that state each frame so script effects are visible.

### Testing
- Attempted an automated build with `make lobby` in this environment, which failed due to missing SDL2/OpenGL development headers (`SDL2/SDL.h` not found), so a full build/run could not be validated here. 
- Unit/runtime verification performed by adding concise log lines (`[EDU_ORB]`, `[EDU_VM]`, `[REALITY]`, `[RIFT]`) to show terminal open/close, compile/run results, builtin calls, and hound events, which will surface when running the built lobby client on a system with SDL2/OpenGL installed.
- No existing automated unit tests were modified or executed as part of this change in the current environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eea502978083278100a9c6b36c1ddd)