### PR TITLE
Add EduScript entity system with spawn/tick bindings

### DIFF
--- a/packages/education/edu_bindings.c
+++ b/packages/education/edu_bindings.c
@@ -29,8 +29,75 @@ static const BuiltinDef G_BUILTINS[] = {
     {"open_portal", EDU_BUILTIN_OPEN_PORTAL, 0},
     {"mark_enemy", EDU_BUILTIN_MARK_ENEMY, 1},
     {"slow_enemy", EDU_BUILTIN_SLOW_ENEMY, 1},
+    {"spawn_prop", EDU_BUILTIN_SPAWN_PROP, 4},
+    {"set_entity_pos", EDU_BUILTIN_SET_ENTITY_POS, 4},
+    {"set_entity_vel", EDU_BUILTIN_SET_ENTITY_VEL, 4},
 };
 
+
+
+static EduEntityType entity_type_from_name(const char *type_name) {
+    if (strcmp(type_name, "crate") == 0) return EDU_ENTITY_PROP_CRATE;
+    if (strcmp(type_name, "gate") == 0) return EDU_ENTITY_GATE;
+    if (strcmp(type_name, "barrel") == 0) return EDU_ENTITY_PROP_BARREL;
+    return EDU_ENTITY_NONE;
+}
+
+static Entity *world_find_entity(EduWorldState *w, int id) {
+    for (int i = 0; i < w->entity_count; i++) {
+        if (w->entities[i].id == id) return &w->entities[i];
+    }
+    return NULL;
+}
+
+static int world_spawn_entity(EduWorldState *w, const char *type_name, float x, float y, float z) {
+    if (w->entity_count >= MAX_EDU_ENTITIES) return -1;
+    EduEntityType t = entity_type_from_name(type_name);
+    if (t == EDU_ENTITY_NONE) return -1;
+    int idx = w->entity_count++;
+    Entity *e = &w->entities[idx];
+    memset(e, 0, sizeof(*e));
+    e->id = idx;
+    e->type = t;
+    e->x = x; e->y = y; e->z = z;
+    e->solid = 1;
+    e->health = 100;
+    snprintf(e->label, sizeof(e->label), "%s", type_name);
+    return e->id;
+}
+
+void world_objects_tick(EduWorldState *w, unsigned int now_ms) {
+    float dt = 0.016f;
+    if (w->entity_tick_last_ms > 0 && now_ms > w->entity_tick_last_ms) {
+        dt = (float)(now_ms - w->entity_tick_last_ms) / 1000.0f;
+        if (dt > 0.1f) dt = 0.1f;
+    }
+    w->entity_tick_last_ms = now_ms;
+
+    for (int i = 0; i < w->entity_count; i++) {
+        Entity *e = &w->entities[i];
+        if (e->frozen) continue;
+        e->vy -= 9.8f * dt;
+        e->x += e->vx * dt;
+        e->y += e->vy * dt;
+        e->z += e->vz * dt;
+        if (e->y < 0.0f) {
+            e->y = 0.0f;
+            if (e->vy < 0.0f) e->vy = 0.0f;
+        }
+    }
+
+    if (w->entity_count == 0 && (w->crate_x != 0 || w->crate_speed != 0)) {
+        int id = world_spawn_entity(w, "crate", (float)w->crate_x, 0.0f, 0.0f);
+        Entity *e = world_find_entity(w, id);
+        if (e) e->vx = (float)w->crate_speed;
+    }
+    Entity *crate = world_find_entity(w, 0);
+    if (crate && crate->type == EDU_ENTITY_PROP_CRATE) {
+        w->crate_x = (int)crate->x;
+        w->crate_speed = (int)crate->vx;
+    }
+}
 int edu_binding_lookup(const char *name, int name_len, int *out_id, int *out_argc) {
     for (int i = 0; i < (int)(sizeof(G_BUILTINS) / sizeof(G_BUILTINS[0])); i++) {
         if ((int)strlen(G_BUILTINS[i].name) == name_len && strncmp(name, G_BUILTINS[i].name, name_len) == 0) {
@@ -56,13 +123,26 @@ int edu_binding_call(EduWorldState *world, int builtin_id, const int *args, int 
     switch (builtin_id) {
         case EDU_BUILTIN_SET_CRATE_SPEED:
             world->crate_speed = args[0];
+            { Entity *e = world_find_entity(world, 0); if (e) e->vx = (float)world->crate_speed; }
             snprintf(debug_out, (size_t)debug_cap, "set_crate_speed(%d)", args[0]);
             return 1;
-        case EDU_BUILTIN_MOVE_CRATE:
-            world->crate_x += world->crate_speed;
+        case EDU_BUILTIN_MOVE_CRATE: {
+            Entity *e = world_find_entity(world, 0);
+            if (!e) {
+                world_spawn_entity(world, "crate", (float)world->crate_x, 0.0f, 0.0f);
+                e = world_find_entity(world, 0);
+            }
+            if (e) {
+                e->vx = (float)world->crate_speed;
+                e->x += e->vx;
+                world->crate_x = (int)e->x;
+            } else {
+                world->crate_x += world->crate_speed;
+            }
             if (world->crate_x > 20) world->quest_make_it_move = 1;
             snprintf(debug_out, (size_t)debug_cap, "move_crate -> x=%d", world->crate_x);
             return 1;
+        }
         case EDU_BUILTIN_STOP_CRATE:
             world->crate_speed = 0;
             snprintf(debug_out, (size_t)debug_cap, "stop_crate");
@@ -160,6 +240,26 @@ int edu_binding_call(EduWorldState *world, int builtin_id, const int *args, int 
             world->enemy_slowed[idx] = 1;
             printf("[RIFT] hound slowed\n");
             snprintf(debug_out, (size_t)debug_cap, "slow_enemy(%d)", idx);
+            return 1;
+        }
+        case EDU_BUILTIN_SPAWN_PROP: {
+            const char *type_name = safe_string(strings, string_count, args[0]);
+            *out_ret = world_spawn_entity(world, type_name, (float)args[1], (float)args[2], (float)args[3]);
+            snprintf(debug_out, (size_t)debug_cap, "spawn_prop(%s,%d,%d,%d) -> %d", type_name, args[1], args[2], args[3], *out_ret);
+            return 1;
+        }
+        case EDU_BUILTIN_SET_ENTITY_POS: {
+            Entity *e = world_find_entity(world, args[0]);
+            if (!e) EDU_FORBIDDEN("entity id out of range");
+            e->x = (float)args[1]; e->y = (float)args[2]; e->z = (float)args[3];
+            snprintf(debug_out, (size_t)debug_cap, "set_entity_pos(%d,%d,%d,%d)", args[0], args[1], args[2], args[3]);
+            return 1;
+        }
+        case EDU_BUILTIN_SET_ENTITY_VEL: {
+            Entity *e = world_find_entity(world, args[0]);
+            if (!e) EDU_FORBIDDEN("entity id out of range");
+            e->vx = (float)args[1]; e->vy = (float)args[2]; e->vz = (float)args[3];
+            snprintf(debug_out, (size_t)debug_cap, "set_entity_vel(%d,%d,%d,%d)", args[0], args[1], args[2], args[3]);
             return 1;
         }
         case EDU_BUILTIN_PRINT:

--- a/packages/education/edu_bindings.h
+++ b/packages/education/edu_bindings.h
@@ -1,6 +1,8 @@
 #ifndef EDU_BINDINGS_H
 #define EDU_BINDINGS_H
 
+#include "edu_entities.h"
+
 typedef struct {
     int crate_speed;
     int crate_x;
@@ -33,6 +35,9 @@ typedef struct {
     float puppet_anim_t;
     int last_print;
     char last_message[96];
+    Entity entities[MAX_EDU_ENTITIES];
+    int entity_count;
+    unsigned int entity_tick_last_ms;
 } EduWorldState;
 
 typedef enum {
@@ -56,6 +61,9 @@ typedef enum {
     EDU_BUILTIN_OPEN_PORTAL,
     EDU_BUILTIN_MARK_ENEMY,
     EDU_BUILTIN_SLOW_ENEMY,
+    EDU_BUILTIN_SPAWN_PROP,
+    EDU_BUILTIN_SET_ENTITY_POS,
+    EDU_BUILTIN_SET_ENTITY_VEL,
     EDU_BUILTIN_COUNT
 } EduBuiltinId;
 
@@ -63,5 +71,6 @@ int edu_binding_lookup(const char *name, int name_len, int *out_id, int *out_arg
 int edu_binding_call(EduWorldState *world, int builtin_id, const int *args, int argc,
                      const char *const *strings, int string_count, int *out_ret,
                      char *debug_out, int debug_cap);
+void world_objects_tick(EduWorldState *w, unsigned int now_ms);
 
 #endif

--- a/packages/education/edu_entities.h
+++ b/packages/education/edu_entities.h
@@ -1,0 +1,28 @@
+#ifndef EDU_ENTITIES_H
+#define EDU_ENTITIES_H
+
+#define MAX_EDU_ENTITIES 64
+
+typedef enum {
+    EDU_ENTITY_NONE = 0,
+    EDU_ENTITY_PROP_CRATE,
+    EDU_ENTITY_GATE,
+    EDU_ENTITY_PROP_BARREL,
+    EDU_ENTITY_PROP_SWITCH
+} EduEntityType;
+
+typedef struct {
+    int id;
+    EduEntityType type;
+    float x, y, z;
+    float vx, vy, vz;
+    float pitch, yaw, roll;
+    int solid;
+    int frozen;
+    int owner_id;
+    char label[32];
+    int health;
+    unsigned int flags;
+} Entity;
+
+#endif

--- a/packages/education/edu_script.c
+++ b/packages/education/edu_script.c
@@ -122,12 +122,16 @@ int edu_script_run_active(EduScriptSystem *sys) {
     meta.strings = s->strings;
     meta.string_count = s->string_count;
     int ok = edu_vm_exec(&vm, s->bytecode, s->bytecode_len, &meta, &sys->world, &lim, sys->run_status, (int)sizeof(sys->run_status));
+    world_objects_tick(&sys->world, 0);
     if (ok) {
         snprintf(sys->last_output, sizeof(sys->last_output), "%.96s | print=%d", vm.debug_line, sys->world.last_print);
         printf("[EDU_VM] run ok instruction_count=%d\n", vm.instruction_count);
     } else {
         snprintf(sys->last_output, sizeof(sys->last_output), "runtime failure");
         printf("[EDU_VM] run error %s\n", sys->run_status);
+    }
+    if (sys->world.entity_count > 0) {
+        snprintf(sys->last_output, sizeof(sys->last_output), "Crate pos: %.2f", sys->world.entities[0].x);
     }
     sys->last_instruction_count = vm.instruction_count;
     return ok;


### PR DESCRIPTION
### Motivation
- Provide a simple in-world entity model so EduScript can spawn and simulate props (crate/gate/etc.) instead of only legacy integer fields. 
- Allow user scripts to create and control dynamic objects and let the existing VM and render path observe entity state for debugging/visibility.

### Description
- Add `packages/education/edu_entities.h` defining `Entity`, `EduEntityType`, and `MAX_EDU_ENTITIES` to hold id/type/transform/physics/owner/flags state. 
- Extend `EduWorldState` with `entities[MAX_EDU_ENTITIES]`, `entity_count`, and `entity_tick_last_ms`, and add new builtin IDs `EDU_BUILTIN_SPAWN_PROP`, `EDU_BUILTIN_SET_ENTITY_POS`, and `EDU_BUILTIN_SET_ENTITY_VEL`. 
- Implement `world_objects_tick(EduWorldState*, unsigned int)` and helpers in `packages/education/edu_bindings.c` including `world_spawn_entity` and `world_find_entity`, with simple velocity integration, gravity, floor clamp, and legacy crate compatibility syncing. 
- Expose VM bindings `spawn_prop(type,x,y,z)`, `set_entity_pos(id,x,y,z)`, and `set_entity_vel(id,vx,vy,vz)`, and forward legacy `set_crate_speed`/`move_crate` to the new entity system. 
- Wire `world_objects_tick` into the VM run path by calling it after `edu_vm_exec` in `edu_script.c` and add a simple overlay text update using `sys->last_output` to show an entity X position (e.g., `Crate pos: X.XX`).

### Testing
- Built the modified education sources with `cc -std=c99 -Ipackages/education -Ipackages/common -c packages/education/edu_bindings.c` and the compile succeeded. 
- Built the script runtime with `cc -std=c99 -Ipackages/education -Ipackages/common -c packages/education/edu_script.c` and the compile succeeded. 
- Verified the VM run path was updated to call `world_objects_tick` and that `sys->last_output` is written with the crate X position when entities exist.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a2b7592948327bef48335f1f255a4)